### PR TITLE
fix: Slack投稿でアシスタントアイコンが表示されない問題を修正

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -181,7 +181,7 @@ func (m *Manager) createSystemHandler(channelID, threadTS string) func(process.S
 				"モデル: %s",
 				msg.SessionID, msg.CWD, msg.Model)
 
-			return m.slackHandler.PostToThread(channelID, threadTS, text)
+			return m.slackHandler.PostAssistantMessage(channelID, threadTS, text)
 		}
 		return nil
 	}
@@ -357,7 +357,7 @@ func (m *Manager) createAssistantHandler(channelID, threadTS string) func(proces
 		}
 
 		if text != "" {
-			return m.slackHandler.PostToThread(channelID, threadTS, text)
+			return m.slackHandler.PostAssistantMessage(channelID, threadTS, text)
 		}
 		return nil
 	}
@@ -395,14 +395,14 @@ func (m *Manager) createResultHandler(channelID, threadTS string) func(process.R
 			}
 		}
 
-		return m.slackHandler.PostToThread(channelID, threadTS, text)
+		return m.slackHandler.PostAssistantMessage(channelID, threadTS, text)
 	}
 }
 
 func (m *Manager) createErrorHandler(channelID, threadTS string) func(error) {
 	return func(err error) {
 		text := fmt.Sprintf("⚠️ エラー: %v", err)
-		m.slackHandler.PostToThread(channelID, threadTS, text)
+		m.slackHandler.PostAssistantMessage(channelID, threadTS, text)
 	}
 }
 
@@ -450,7 +450,7 @@ func (m *Manager) CleanupIdleSessions(maxIdleTime time.Duration) {
 					"セッションID: %s\n\n"+
 					"新しいセッションを開始するには、再度メンションしてください。",
 					idleMinutes, sessionID)
-				m.slackHandler.PostToThread(session.ChannelID, session.ThreadTS, message)
+				m.slackHandler.PostAssistantMessage(session.ChannelID, session.ThreadTS, message)
 			}
 
 			// Close Claude process


### PR DESCRIPTION
## 概要
- Claude Codeからの応答でアイコンが表示されない問題を修正
-  を  に変更することで、設定されたアイコンとユーザー名が表示されるように

## 変更内容  
-  のメッセージハンドラーを修正
- システム、アシスタント、結果、エラー、タイムアウトメッセージすべてでアイコン表示

## テスト
-  - Pass ✅
- ok  	github.com/yuya-takeyama/cc-slack/cmd/cc-slack	(cached)
?   	github.com/yuya-takeyama/cc-slack/cmd/cc-slack-manager	[no test files]
?   	github.com/yuya-takeyama/cc-slack/internal/mcp	[no test files]
ok  	github.com/yuya-takeyama/cc-slack/internal/process	(cached)
ok  	github.com/yuya-takeyama/cc-slack/internal/session	(cached)
ok  	github.com/yuya-takeyama/cc-slack/internal/slack	(cached) - Pass ✅
-  - Pass ✅

🤖 Generated with [Claude Code](https://claude.ai/code)