### PR TITLE
feat(session): improve session duration display and add tool notifications

### DIFF
--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -137,3 +137,71 @@ func TestSessionTimeoutMessage(t *testing.T) {
 		t.Error("Expected message to contain restart instructions")
 	}
 }
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		ms       int
+		expected string
+	}{
+		{
+			name:     "less than 1 minute",
+			ms:       5000,
+			expected: "5秒",
+		},
+		{
+			name:     "exactly 1 minute",
+			ms:       60000,
+			expected: "1分0秒",
+		},
+		{
+			name:     "2 minutes 5 seconds",
+			ms:       125000,
+			expected: "2分5秒",
+		},
+		{
+			name:     "59 minutes 59 seconds",
+			ms:       3599000,
+			expected: "59分59秒",
+		},
+		{
+			name:     "exactly 1 hour",
+			ms:       3600000,
+			expected: "1時間0分0秒",
+		},
+		{
+			name:     "1 hour 1 minute 5 seconds",
+			ms:       3665000,
+			expected: "1時間1分5秒",
+		},
+		{
+			name:     "2 hours 30 minutes 45 seconds",
+			ms:       9045000,
+			expected: "2時間30分45秒",
+		},
+		{
+			name:     "realistic example from description",
+			ms:       296414,
+			expected: "4分56秒",
+		},
+		{
+			name:     "0 seconds",
+			ms:       0,
+			expected: "0秒",
+		},
+		{
+			name:     "999 milliseconds (rounds down)",
+			ms:       999,
+			expected: "0秒",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatDuration(tt.ms)
+			if result != tt.expected {
+				t.Errorf("formatDuration(%d) = %s, want %s", tt.ms, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
セッション完了時の実行時間表示を改善し、ツール実行の通知機能を追加しました。

## 変更内容

### 1. 実行時間の表示改善
- ミリ秒表示から人間が読みやすい形式に変更
  - 例: `296414ms` → `4分56秒`
  - 1時間以上の場合は `1時間1分5秒` のように表示

### 2. ツール通知の追加
- WriteツールとLSツールの実行時にSlackに通知を送信
- 相対パス表示で見やすく
- ツール専用のアイコンとユーザー名で表示

### 3. テストの追加
- `formatDuration` 関数の包括的な単体テストを実装
- 0秒から数時間まで様々なケースをカバー

## 動作確認
- [ ] セッション完了時の実行時間が日本語形式で表示される
- [ ] Writeツール実行時に Writing `path/to/file` が表示される
- [ ] LSツール実行時に Listing `path/to/dir` が表示される
- [ ] 単体テストが全てパスする

## スクリーンショット
（実際の動作画面を後で追加予定）