### PR TITLE
feat: SlackでBashコマンドをコードブロックで表示

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -286,8 +286,12 @@ func (m *Manager) createAssistantHandler(channelID, threadTS string) func(proces
 				} else if content.Name == "Bash" && content.Input != nil {
 					// Extract command from input
 					if cmd, ok := content.Input["command"].(string); ok {
+						// Escape triple backticks in command
+						escapedCmd := strings.ReplaceAll(cmd, "```", "\\`\\`\\`")
+						// Format command as code block
+						formattedCmd := fmt.Sprintf("```\n%s\n```", escapedCmd)
 						// Post using tool-specific icon and username
-						if err := m.slackHandler.PostToolMessage(channelID, threadTS, fmt.Sprintf("`%s`", cmd), ccslack.ToolBash); err != nil {
+						if err := m.slackHandler.PostToolMessage(channelID, threadTS, formattedCmd, ccslack.ToolBash); err != nil {
 							fmt.Printf("Failed to post Bash tool to Slack: %v\n", err)
 						}
 					}


### PR DESCRIPTION
## Summary
- Bashツールのコマンドをコードブロック (triple backticks) で囲むように変更
- コマンド内にtriple backtickが含まれる場合はバックスラッシュでエスケープ
- Slack上でコマンドがモノスペースフォントで見やすく表示される

## Test plan
- [ ] Bashコマンドが実行された際、Slackにコードブロックで表示されることを確認
- [ ] コマンド内にtriple backtickが含まれる場合、正しくエスケープされることを確認
- [ ] 既存のテストがすべてパスすることを確認（完了済み）