### PR TITLE
feat(slack): improve Task tool messages with description and prompt display

### DIFF
--- a/internal/messages/format.go
+++ b/internal/messages/format.go
@@ -86,6 +86,21 @@ func FormatGlobToolMessage(pattern string) string {
 	return fmt.Sprintf("`%s`", pattern)
 }
 
+// FormatTaskToolMessage formats the Task tool message
+func FormatTaskToolMessage(description, prompt string) string {
+	// Truncate prompt if too long
+	const maxPromptLength = 500
+	truncatedPrompt := prompt
+	if len(prompt) > maxPromptLength {
+		truncatedPrompt = prompt[:maxPromptLength] + "..."
+	}
+
+	// Escape triple backticks in prompt
+	escapedPrompt := strings.ReplaceAll(truncatedPrompt, "```", "\\`\\`\\`")
+
+	return fmt.Sprintf("Task: %s\n```\n%s\n```", description, escapedPrompt)
+}
+
 // FormatDuration converts duration to human-readable string
 // Examples:
 //   - 5s -> "5秒"

--- a/internal/messages/format_test.go
+++ b/internal/messages/format_test.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -354,6 +355,43 @@ func TestFormatGlobToolMessage(t *testing.T) {
 			got := FormatGlobToolMessage(tt.pattern)
 			if got != tt.want {
 				t.Errorf("FormatGlobToolMessage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatTaskToolMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		prompt      string
+		want        string
+	}{
+		{
+			name:        "simple task",
+			description: "コードベース全体を分析",
+			prompt:      "Analyze the codebase and find issues",
+			want:        "Task: コードベース全体を分析\n```\nAnalyze the codebase and find issues\n```",
+		},
+		{
+			name:        "long prompt truncated",
+			description: "Complex analysis",
+			prompt:      strings.Repeat("a", 600),
+			want:        "Task: Complex analysis\n```\n" + strings.Repeat("a", 500) + "...\n```",
+		},
+		{
+			name:        "prompt with triple backticks",
+			description: "Code generation",
+			prompt:      "Generate code with ```python\nprint('hello')\n```",
+			want:        "Task: Code generation\n```\nGenerate code with \\`\\`\\`python\nprint('hello')\n\\`\\`\\`\n```",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatTaskToolMessage(tt.description, tt.prompt)
+			if got != tt.want {
+				t.Errorf("FormatTaskToolMessage() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -368,6 +368,16 @@ func (m *Manager) createAssistantHandler(channelID, threadTS string) func(proces
 							fmt.Printf("Failed to post LS tool to Slack: %v\n", err)
 						}
 					}
+				} else if content.Name == "Task" && content.Input != nil {
+					// Handle Task tool
+					description, _ := content.Input["description"].(string)
+					prompt, _ := content.Input["prompt"].(string)
+
+					message := messages.FormatTaskToolMessage(description, prompt)
+					// Post using tool-specific icon and username
+					if err := m.slackHandler.PostToolMessage(channelID, threadTS, message, ccslack.ToolTask); err != nil {
+						fmt.Printf("Failed to post Task tool to Slack: %v\n", err)
+					}
 				} else {
 					// Other tools - use tool-specific display or fallback
 					if err := m.slackHandler.PostToolMessage(channelID, threadTS, content.Name, content.Name); err != nil {


### PR DESCRIPTION
## Summary
- Task toolの実行時にdescriptionとpromptの両方をSlackに表示するように改善
- promptは長すぎる場合は500文字で切り捨てて...を付ける
- ロボット絵文字（🤖）でTask toolを識別しやすく

## Test plan
- [x] FormatTaskToolMessage関数の単体テストを追加
- [x] go vet ./... でエラーがないことを確認
- [x] go test ./... で全テストがパスすることを確認
- [ ] 実際にSlackでTask toolが実行された際のメッセージ表示を確認