### PR TITLE
docs: clarify restart instructions to be manual-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,16 +91,16 @@ Claude Code Hooks automatically runs goimports, which removes unused imports. To
 - Add imports afterwards (or let goimports auto-add them)
 - When multiple imports are needed, write the code that uses them before organizing imports
 
-### Development Workflow with Auto-Restart
+### Development Workflow with Restart
 
-During development, use the cc-slack-manager for automatic restarts:
+During development, use the cc-slack-manager for restarting cc-slack:
 
-**After making code changes, restart cc-slack:**
+**To restart cc-slack when explicitly requested:**
 ```bash
 ./scripts/restart
 ```
 
-**Claude Code should automatically run the restart script after significant code changes to cc-slack.**
+**Important:** Claude Code should only run the restart script when explicitly requested by the user. Do not automatically restart after code changes, as this will terminate cc-slack and end the current session.
 
 ### Checking cc-slack Status
 


### PR DESCRIPTION
## Summary
- Clarifies that cc-slack restarts should only happen when explicitly requested by the user
- Removes instruction for automatic restart after code changes
- Explains that automatic restarts would terminate cc-slack and end the session

## Context
The previous instructions suggested that Claude Code should automatically restart cc-slack after significant code changes. However, this is problematic because:
- Restarting cc-slack terminates the process
- This causes the entire Claude Code session to end unexpectedly
- The user loses their context and progress

## Changes
- Updated the Development Workflow with Restart section in CLAUDE.md
- Changed title from Auto-Restart to Restart to reflect manual nature
- Added explicit warning about not restarting automatically