### PR TITLE
feat(messages): enhance Read tool messages with line range information

### DIFF
--- a/internal/messages/format.go
+++ b/internal/messages/format.go
@@ -54,8 +54,19 @@ func FormatBashToolMessage(command string) string {
 }
 
 // FormatReadToolMessage formats the Read tool message
-func FormatReadToolMessage(filePath string) string {
-	return fmt.Sprintf("`%s`", filePath)
+func FormatReadToolMessage(filePath string, offset, limit int) string {
+	if offset > 0 || limit > 0 {
+		// Include line range information when offset or limit is specified
+		if offset > 0 && limit > 0 {
+			return fmt.Sprintf("Reading `%s` (lines %d-%d)", filePath, offset, offset+limit-1)
+		} else if offset > 0 {
+			return fmt.Sprintf("Reading `%s` (from line %d)", filePath, offset)
+		} else {
+			return fmt.Sprintf("Reading `%s` (first %d lines)", filePath, limit)
+		}
+	}
+	// Default format when reading entire file
+	return fmt.Sprintf("Reading `%s`", filePath)
 }
 
 // FormatGrepToolMessage formats the Grep tool message

--- a/internal/messages/format_test.go
+++ b/internal/messages/format_test.go
@@ -182,28 +182,57 @@ func TestFormatReadToolMessage(t *testing.T) {
 	tests := []struct {
 		name     string
 		filePath string
+		offset   int
+		limit    int
 		want     string
 	}{
 		{
-			name:     "simple path",
+			name:     "simple path - entire file",
 			filePath: "main.go",
-			want:     "`main.go`",
+			offset:   0,
+			limit:    0,
+			want:     "Reading `main.go`",
 		},
 		{
-			name:     "path with spaces",
+			name:     "path with spaces - entire file",
 			filePath: "my file.txt",
-			want:     "`my file.txt`",
+			offset:   0,
+			limit:    0,
+			want:     "Reading `my file.txt`",
 		},
 		{
-			name:     "absolute path",
+			name:     "absolute path - entire file",
 			filePath: "/Users/name/project/src/main.go",
-			want:     "`/Users/name/project/src/main.go`",
+			offset:   0,
+			limit:    0,
+			want:     "Reading `/Users/name/project/src/main.go`",
+		},
+		{
+			name:     "with offset and limit",
+			filePath: "main.go",
+			offset:   100,
+			limit:    50,
+			want:     "Reading `main.go` (lines 100-149)",
+		},
+		{
+			name:     "with offset only",
+			filePath: "config.json",
+			offset:   200,
+			limit:    0,
+			want:     "Reading `config.json` (from line 200)",
+		},
+		{
+			name:     "with limit only",
+			filePath: "README.md",
+			offset:   0,
+			limit:    100,
+			want:     "Reading `README.md` (first 100 lines)",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatReadToolMessage(tt.filePath)
+			got := FormatReadToolMessage(tt.filePath, tt.offset, tt.limit)
 			if got != tt.want {
 				t.Errorf("FormatReadToolMessage() = %v, want %v", got, tt.want)
 			}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -293,7 +293,18 @@ func (m *Manager) createAssistantHandler(channelID, threadTS string) func(proces
 					if filePath, ok := content.Input["file_path"].(string); ok {
 						// Get relative path from work directory
 						relPath := m.getRelativePath(channelID, threadTS, filePath)
-						message := messages.FormatReadToolMessage(relPath)
+
+						// Get optional offset and limit parameters
+						offset := 0
+						limit := 0
+						if offsetVal, ok := content.Input["offset"].(float64); ok {
+							offset = int(offsetVal)
+						}
+						if limitVal, ok := content.Input["limit"].(float64); ok {
+							limit = int(limitVal)
+						}
+
+						message := messages.FormatReadToolMessage(relPath, offset, limit)
 						// Post using tool-specific icon and username
 						if err := m.slackHandler.PostToolMessage(channelID, threadTS, message, ccslack.ToolRead); err != nil {
 							fmt.Printf("Failed to post Read tool to Slack: %v\n", err)


### PR DESCRIPTION
## Summary
- Update FormatReadToolMessage to display line range info when offset/limit is specified
- Show Reading `file.go` (lines 100-149) instead of just `file.go`
- Make Read tool messages consistent with other tools (e.g., Editing `file.go`)

## Test plan
- [x] Unit tests for FormatReadToolMessage with various offset/limit combinations
- [x] Static analysis passes (go vet)
- [x] All tests pass (go test)
- [ ] Manual testing with actual Claude Code sessions

🤖 Generated with Claude Code