### PR TITLE
fix: Thinking メッセージの過剰な改行を削除し、純粋関数を抽出

### DIFF
--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1,0 +1,213 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/slack-go/slack"
+)
+
+func TestTrimNewlines(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "No newlines",
+			input:    "Hello World",
+			expected: "Hello World",
+		},
+		{
+			name:     "Leading newlines",
+			input:    "\n\nHello World",
+			expected: "Hello World",
+		},
+		{
+			name:     "Trailing newlines",
+			input:    "Hello World\n\n",
+			expected: "Hello World",
+		},
+		{
+			name:     "Both leading and trailing newlines",
+			input:    "\n\nHello World\n\n",
+			expected: "Hello World",
+		},
+		{
+			name:     "Massive amount of newlines like in the bug",
+			input:    "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n良い！テストが成功しました。次に、configのテストも実行します。",
+			expected: "良い！テストが成功しました。次に、configのテストも実行します。",
+		},
+		{
+			name:     "Mixed newlines (LF and CRLF)",
+			input:    "\r\n\r\nHello World\r\n\r\n",
+			expected: "Hello World",
+		},
+		{
+			name:     "Only newlines",
+			input:    "\n\n\n\n",
+			expected: "",
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "Newlines in the middle are preserved",
+			input:    "\n\nHello\nWorld\n\n",
+			expected: "Hello\nWorld",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := trimNewlines(tt.input)
+			if result != tt.expected {
+				t.Errorf("trimNewlines(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFormatThreadKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		channelID string
+		threadTS  string
+		expected  string
+	}{
+		{
+			name:      "Normal key",
+			channelID: "C1234567890",
+			threadTS:  "1234567890.123456",
+			expected:  "C1234567890:1234567890.123456",
+		},
+		{
+			name:      "Empty channel ID",
+			channelID: "",
+			threadTS:  "1234567890.123456",
+			expected:  ":1234567890.123456",
+		},
+		{
+			name:      "Empty thread TS",
+			channelID: "C1234567890",
+			threadTS:  "",
+			expected:  "C1234567890:",
+		},
+		{
+			name:      "Both empty",
+			channelID: "",
+			threadTS:  "",
+			expected:  ":",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatThreadKey(tt.channelID, tt.threadTS)
+			if result != tt.expected {
+				t.Errorf("formatThreadKey(%q, %q) = %q, want %q", tt.channelID, tt.threadTS, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetPriorityTextStyle(t *testing.T) {
+	tests := []struct {
+		name     string
+		priority string
+		expected *slack.RichTextSectionTextStyle
+	}{
+		{
+			name:     "High priority",
+			priority: "high",
+			expected: &slack.RichTextSectionTextStyle{Bold: true},
+		},
+		{
+			name:     "Low priority",
+			priority: "low",
+			expected: &slack.RichTextSectionTextStyle{Italic: true},
+		},
+		{
+			name:     "Medium priority",
+			priority: "medium",
+			expected: nil,
+		},
+		{
+			name:     "Unknown priority",
+			priority: "unknown",
+			expected: nil,
+		},
+		{
+			name:     "Empty priority",
+			priority: "",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getPriorityTextStyle(tt.priority)
+			if tt.expected == nil {
+				if result != nil {
+					t.Errorf("getPriorityTextStyle(%q) = %v, want nil", tt.priority, result)
+				}
+			} else {
+				if result == nil {
+					t.Errorf("getPriorityTextStyle(%q) = nil, want %v", tt.priority, tt.expected)
+				} else if result.Bold != tt.expected.Bold || result.Italic != tt.expected.Italic {
+					t.Errorf("getPriorityTextStyle(%q) = %v, want %v", tt.priority, result, tt.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestComputeRelativePath(t *testing.T) {
+	tests := []struct {
+		name         string
+		workDir      string
+		absolutePath string
+		expected     string
+	}{
+		{
+			name:         "Normal relative path",
+			workDir:      "/home/user/project",
+			absolutePath: "/home/user/project/src/main.go",
+			expected:     "src/main.go",
+		},
+		{
+			name:         "Same directory",
+			workDir:      "/home/user/project",
+			absolutePath: "/home/user/project",
+			expected:     ".",
+		},
+		{
+			name:         "Parent directory",
+			workDir:      "/home/user/project/src",
+			absolutePath: "/home/user/project",
+			expected:     "..",
+		},
+		{
+			name:         "Different root",
+			workDir:      "/home/user/project",
+			absolutePath: "/var/log/app.log",
+			expected:     "../../../var/log/app.log",
+		},
+		{
+			name:         "Work dir with trailing slash",
+			workDir:      "/home/user/project/",
+			absolutePath: "/home/user/project/src/main.go",
+			expected:     "src/main.go",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := computeRelativePath(tt.workDir, tt.absolutePath)
+			if result != tt.expected {
+				t.Errorf("computeRelativePath(%q, %q) = %q, want %q", tt.workDir, tt.absolutePath, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要

Slack に投稿される Thinking メッセージに大量の改行が含まれる問題を修正し、併せて manager.go から純粋関数を抽出してテストカバレッジを向上させました。

## 変更内容

### 1. Thinking メッセージの改行削除機能追加
-  関数を実装し、メッセージの先頭と末尾の改行（\n と \r）を全て削除
- 実際のバグケース（100行以上の改行）を含むテストケースを追加

### 2. 純粋関数の抽出とテスト追加
以下の機能を純粋関数として抽出し、それぞれに網羅的なユニットテストを追加：

- **formatThreadKey**: channelID と threadTS から一意のキーを生成
- **getPriorityTextStyle**: Todo の優先度（high/medium/low）から Slack のテキストスタイルへ変換
- **computeRelativePath**: 絶対パスから作業ディレクトリからの相対パスを計算

## テスト

- 全ての新規関数に対してテーブル駆動テストを実装
- エッジケース（空文字列、パス区切り文字など）も網羅
- 全テスト通過 & go vet クリア

## 関連 Issue

なし（バグ報告のみ）