### PR TITLE
feat(slack): improve WebFetch tool message display with URL and prompt

### DIFF
--- a/internal/messages/format.go
+++ b/internal/messages/format.go
@@ -112,6 +112,21 @@ func FormatTaskToolMessage(description, prompt string) string {
 	return fmt.Sprintf("Task: %s\n```\n%s\n```", description, escapedPrompt)
 }
 
+// FormatWebFetchToolMessage formats the WebFetch tool message
+func FormatWebFetchToolMessage(url, prompt string) string {
+	// Truncate prompt if too long
+	const maxPromptLength = 300
+	truncatedPrompt := prompt
+	if len(prompt) > maxPromptLength {
+		truncatedPrompt = prompt[:maxPromptLength] + "..."
+	}
+
+	// Escape triple backticks in prompt
+	escapedPrompt := strings.ReplaceAll(truncatedPrompt, "```", "\\`\\`\\`")
+
+	return fmt.Sprintf("Fetching: <%s>\n```\n%s\n```", url, escapedPrompt)
+}
+
 // FormatCompletionMessage formats the completion message with session info
 func FormatCompletionMessage(sessionID string, turns int, cost float64) string {
 	text := fmt.Sprintf("✅ セッション完了\n"+

--- a/internal/messages/format_test.go
+++ b/internal/messages/format_test.go
@@ -426,6 +426,49 @@ func TestFormatTaskToolMessage(t *testing.T) {
 	}
 }
 
+func TestFormatWebFetchToolMessage(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		prompt string
+		want   string
+	}{
+		{
+			name:   "simple web fetch",
+			url:    "https://example.com",
+			prompt: "Extract the main content",
+			want:   "Fetching: <https://example.com>\n```\nExtract the main content\n```",
+		},
+		{
+			name:   "blog post fetch",
+			url:    "https://blog.yuyat.jp/post/how-i-learn-about-cloud-services/",
+			prompt: "Extract the article title, content summary, date, key points about learning cloud services, and any specific techniques or resources mentioned",
+			want:   "Fetching: <https://blog.yuyat.jp/post/how-i-learn-about-cloud-services/>\n```\nExtract the article title, content summary, date, key points about learning cloud services, and any specific techniques or resources mentioned\n```",
+		},
+		{
+			name:   "long prompt truncated",
+			url:    "https://docs.example.com/api",
+			prompt: strings.Repeat("a", 400),
+			want:   "Fetching: <https://docs.example.com/api>\n```\n" + strings.Repeat("a", 300) + "...\n```",
+		},
+		{
+			name:   "prompt with triple backticks",
+			url:    "https://github.com/user/repo",
+			prompt: "Extract code samples ```javascript\nconsole.log('test');\n```",
+			want:   "Fetching: <https://github.com/user/repo>\n```\nExtract code samples \\`\\`\\`javascript\nconsole.log('test');\n\\`\\`\\`\n```",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatWebFetchToolMessage(tt.url, tt.prompt)
+			if got != tt.want {
+				t.Errorf("FormatWebFetchToolMessage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFormatDuration(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -530,6 +530,16 @@ func (m *Manager) createAssistantHandler(channelID, threadTS string) func(proces
 					if err := m.slackHandler.PostToolMessage(channelID, threadTS, message, ccslack.ToolTask); err != nil {
 						fmt.Printf("Failed to post Task tool to Slack: %v\n", err)
 					}
+				} else if content.Name == "WebFetch" && content.Input != nil {
+					// Handle WebFetch tool
+					url, _ := content.Input["url"].(string)
+					prompt, _ := content.Input["prompt"].(string)
+
+					message := messages.FormatWebFetchToolMessage(url, prompt)
+					// Post using tool-specific icon and username
+					if err := m.slackHandler.PostToolMessage(channelID, threadTS, message, ccslack.ToolWebFetch); err != nil {
+						fmt.Printf("Failed to post WebFetch tool to Slack: %v\n", err)
+					}
 				} else {
 					// Other tools - use tool-specific display or fallback
 					if err := m.slackHandler.PostToolMessage(channelID, threadTS, content.Name, content.Name); err != nil {


### PR DESCRIPTION
## 概要

WebFetch ツールの Slack 投稿を改善し、URL と prompt の情報を含めるようにしました。

## 変更内容

- FormatWebFetchToolMessage 関数を追加して、URL と prompt を見やすい形式で表示
- セッションマネージャーで WebFetch ツールメッセージを適切に処理するよう修正
- WebFetch メッセージフォーマットの包括的なテストを追加
- URL は角括弧内に、prompt はコードブロック内に表示して可読性を向上

## 詳細な変更

### internal/messages/format.go
- FormatWebFetchToolMessage(url, prompt string) 関数を追加
- prompt が長い場合の切り詰め処理（300文字制限）
- 三重バッククォートのエスケープ処理

### internal/session/manager.go
- WebFetch ツールの処理分岐を追加
- URL と prompt を抽出して適切なフォーマットで Slack に投稿

### internal/messages/format_test.go
- WebFetch メッセージフォーマットのテストケースを追加
- 通常のケース、長いprompt、バッククォートを含むケースなどをカバー

## テスト結果

すべてのテストが成功することを確認済み。

## 期待される効果

WebFetch ツール使用時の表示が改善され、どのURLを取得し、どのような指示でWebFetchを実行しているかが一目でわかるようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)
