### PR TITLE
feat(slack): improve approval message display with rich text formatting

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -209,6 +209,11 @@ func (s *Server) HandleApprovalPrompt(ctx context.Context, session *mcpsdk.Serve
 				if description, ok := params.Arguments.Input["description"].(string); ok && description != "" {
 					message += fmt.Sprintf("\n**説明**: %s", description)
 				}
+
+				// Handle Write tool
+				if filePath, ok := params.Arguments.Input["file_path"].(string); ok {
+					message += fmt.Sprintf("\n\n**ファイルパス**: %s", filePath)
+				}
 			}
 
 			err := s.slackPoster.PostApprovalRequest(channelID, threadTS, message, requestID)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -192,13 +192,22 @@ func (s *Server) HandleApprovalPrompt(ctx context.Context, session *mcpsdk.Serve
 
 			// Add tool input details if available
 			if params.Arguments.Input != nil {
+				// Handle WebFetch tool
 				if url, ok := params.Arguments.Input["url"].(string); ok {
 					message += fmt.Sprintf("\n\n**URL**: %s", url)
 				}
 				if prompt, ok := params.Arguments.Input["prompt"].(string); ok && len(prompt) > 100 {
 					message += fmt.Sprintf("\n**内容**: %s...", prompt[:100])
-				} else if prompt != "" {
+				} else if prompt, ok := params.Arguments.Input["prompt"].(string); ok && prompt != "" {
 					message += fmt.Sprintf("\n**内容**: %s", prompt)
+				}
+
+				// Handle Bash tool
+				if command, ok := params.Arguments.Input["command"].(string); ok {
+					message += fmt.Sprintf("\n\n**コマンド**: %s", command)
+				}
+				if description, ok := params.Arguments.Input["description"].(string); ok && description != "" {
+					message += fmt.Sprintf("\n**説明**: %s", description)
 				}
 			}
 

--- a/internal/slack/handler.go
+++ b/internal/slack/handler.go
@@ -555,8 +555,6 @@ func buildApprovalRichTextElements(toolName, url, prompt string) []slack.RichTex
 
 	// Header
 	elements = append(elements, slack.NewRichTextSection(
-		slack.NewRichTextSectionEmojiElement("lock", 0, nil),
-		slack.NewRichTextSectionTextElement(" ", nil),
 		slack.NewRichTextSectionTextElement("ツールの実行許可が必要です", &slack.RichTextSectionTextStyle{Bold: true}),
 	))
 
@@ -584,20 +582,19 @@ func buildApprovalRichTextElements(toolName, url, prompt string) []slack.RichTex
 	if prompt != "" {
 		// Content/Prompt
 		elements = append(elements, slack.NewRichTextSection(
-			slack.NewRichTextSectionTextElement("内容: ", &slack.RichTextSectionTextStyle{Bold: true}),
+			slack.NewRichTextSectionTextElement("内容:", &slack.RichTextSectionTextStyle{Bold: true}),
 		))
 
-		// Add prompt with appropriate styling
-		if len(prompt) > 100 {
-			// For long prompts, use code style
-			elements = append(elements, slack.NewRichTextSection(
-				slack.NewRichTextSectionTextElement(prompt, &slack.RichTextSectionTextStyle{Code: true}),
-			))
-		} else {
-			elements = append(elements, slack.NewRichTextSection(
-				slack.NewRichTextSectionTextElement(prompt, &slack.RichTextSectionTextStyle{Italic: true}),
-			))
-		}
+		// Add prompt as code block style with triple quotes
+		elements = append(elements, slack.NewRichTextSection(
+			slack.NewRichTextSectionTextElement("```", &slack.RichTextSectionTextStyle{Code: true}),
+		))
+		elements = append(elements, slack.NewRichTextSection(
+			slack.NewRichTextSectionTextElement(prompt, &slack.RichTextSectionTextStyle{Code: true}),
+		))
+		elements = append(elements, slack.NewRichTextSection(
+			slack.NewRichTextSectionTextElement("```", &slack.RichTextSectionTextStyle{Code: true}),
+		))
 	}
 
 	return elements

--- a/internal/slack/handler.go
+++ b/internal/slack/handler.go
@@ -587,13 +587,13 @@ func buildApprovalRichTextElements(toolName, url, prompt string) []slack.RichTex
 
 		// Add prompt as code block style with triple quotes
 		elements = append(elements, slack.NewRichTextSection(
-			slack.NewRichTextSectionTextElement("```", &slack.RichTextSectionTextStyle{Code: true}),
+			slack.NewRichTextSectionTextElement("```", nil),
 		))
 		elements = append(elements, slack.NewRichTextSection(
 			slack.NewRichTextSectionTextElement(prompt, &slack.RichTextSectionTextStyle{Code: true}),
 		))
 		elements = append(elements, slack.NewRichTextSection(
-			slack.NewRichTextSectionTextElement("```", &slack.RichTextSectionTextStyle{Code: true}),
+			slack.NewRichTextSectionTextElement("```", nil),
 		))
 	}
 

--- a/internal/slack/handler.go
+++ b/internal/slack/handler.go
@@ -540,6 +540,7 @@ type ApprovalInfo struct {
 	Prompt      string
 	Command     string
 	Description string
+	FilePath    string
 }
 
 // parseApprovalMessage parses the approval message from mcp/server.go to extract structured information
@@ -562,6 +563,8 @@ func parseApprovalMessage(message string) *ApprovalInfo {
 			info.Command = strings.TrimPrefix(line, "**コマンド**: ")
 		} else if strings.HasPrefix(line, "**説明**: ") {
 			info.Description = strings.TrimPrefix(line, "**説明**: ")
+		} else if strings.HasPrefix(line, "**ファイルパス**: ") {
+			info.FilePath = strings.TrimPrefix(line, "**ファイルパス**: ")
 		}
 	}
 
@@ -601,6 +604,11 @@ func buildApprovalMarkdownText(info *ApprovalInfo) string {
 		}
 		text.WriteString("*説明:*\n")
 		text.WriteString(fmt.Sprintf("```\n%s\n```", info.Description))
+	}
+
+	// Handle Write tool
+	if info.FilePath != "" {
+		text.WriteString(fmt.Sprintf("*ファイルパス:* `%s`", info.FilePath))
 	}
 
 	return text.String()

--- a/internal/tools/display.go
+++ b/internal/tools/display.go
@@ -19,7 +19,8 @@ const (
 	ToolNotebookEdit = "NotebookEdit"
 
 	// Special message types
-	MessageThinking = "thinking"
+	MessageThinking       = "thinking"
+	MessageApprovalPrompt = "approval_prompt"
 )
 
 // ToolInfo holds display information for tools
@@ -48,7 +49,8 @@ var toolInfoMap = map[string]ToolInfo{
 	ToolNotebookEdit: {Name: "NotebookEdit", Emoji: "📔", SlackIcon: ":notebook_with_decorative_cover:"},
 
 	// Special message types
-	MessageThinking: {Name: "Thinking", Emoji: "🤔", SlackIcon: ":thinking_face:"},
+	MessageThinking:       {Name: "Thinking", Emoji: "🤔", SlackIcon: ":thinking_face:"},
+	MessageApprovalPrompt: {Name: "Permission", Emoji: "🔐", SlackIcon: ":lock:"},
 }
 
 // GetToolInfo returns tool information for the given tool name


### PR DESCRIPTION
## 概要

permission取得時のSlackメッセージをrich textを使って大幅に改善し、ユーザー体験を向上させました。

## 主な改善点

### 1. Rich Text フォーマット対応
- マークダウン形式からSlack Rich Textに変更
- 適切なボールド、リンク、コードスタイリングの適用
- フォーマット崩れの解消

### 2. ツール固有の表示改善
- Permission アイコンとユーザー名を追加
- ツール情報をtools/display.goに追加

### 3. 承認後のメッセージ更新改善
- 元のメッセージ構造を保持
- 新しいステータスブロックを追加する方式に変更
- 誰が承認/拒否したかのユーザー情報を表示

## 技術的な変更

- PostApprovalRequestメソッドを完全にリライト
- handleApprovalActionメソッドを改善
- 複数のヘルパー関数を追加

## テスト結果

全てのテストが通過することを確認済み。

🤖 Generated with [Claude Code](https://claude.ai/code)