### PR TITLE
セッションIDをインラインコードフォーマットで表示

### DIFF
--- a/internal/messages/format.go
+++ b/internal/messages/format.go
@@ -9,7 +9,7 @@ import (
 // FormatSessionStartMessage formats the session start message
 func FormatSessionStartMessage(sessionID, cwd, model string) string {
 	return fmt.Sprintf("🚀 Claude Code セッション開始\n"+
-		"セッションID: %s\n"+
+		"セッションID: `%s`\n"+
 		"作業ディレクトリ: %s\n"+
 		"モデル: %s",
 		sessionID, cwd, model)
@@ -40,7 +40,7 @@ func FormatSessionCompleteMessage(duration time.Duration, turns int, cost float6
 func FormatTimeoutMessage(idleMinutes int, sessionID string) string {
 	return fmt.Sprintf("⏰ セッションがタイムアウトしました\n"+
 		"アイドル時間: %d分\n"+
-		"セッションID: %s\n\n"+
+		"セッションID: `%s`\n\n"+
 		"新しいセッションを開始するには、再度メンションしてください。",
 		idleMinutes, sessionID)
 }
@@ -130,7 +130,7 @@ func FormatWebFetchToolMessage(url, prompt string) string {
 // FormatCompletionMessage formats the completion message with session info
 func FormatCompletionMessage(sessionID string, turns int, cost float64) string {
 	text := fmt.Sprintf("✅ セッション完了\n"+
-		"セッションID: %s\n"+
+		"セッションID: `%s`\n"+
 		"ターン数: %d\n"+
 		"コスト: $%.6f USD",
 		sessionID, turns, cost)
@@ -146,7 +146,7 @@ func FormatCompletionMessage(sessionID string, turns int, cost float64) string {
 // FormatErrorMessage formats the error completion message
 func FormatErrorMessage(sessionID string) string {
 	return fmt.Sprintf("❌ セッションがエラーで終了しました\n"+
-		"セッションID: %s", sessionID)
+		"セッションID: `%s`", sessionID)
 }
 
 // FormatDuration converts duration to human-readable string

--- a/internal/messages/format_test.go
+++ b/internal/messages/format_test.go
@@ -469,6 +469,85 @@ func TestFormatWebFetchToolMessage(t *testing.T) {
 	}
 }
 
+func TestFormatCompletionMessage(t *testing.T) {
+	tests := []struct {
+		name      string
+		sessionID string
+		turns     int
+		cost      float64
+		want      string
+	}{
+		{
+			name:      "normal session",
+			sessionID: "session-123",
+			turns:     5,
+			cost:      0.05,
+			want: "✅ セッション完了\n" +
+				"セッションID: `session-123`\n" +
+				"ターン数: 5\n" +
+				"コスト: $0.050000 USD",
+		},
+		{
+			name:      "high cost session",
+			sessionID: "session-456",
+			turns:     20,
+			cost:      1.5,
+			want: "✅ セッション完了\n" +
+				"セッションID: `session-456`\n" +
+				"ターン数: 20\n" +
+				"コスト: $1.500000 USD\n" +
+				"⚠️ 高コストセッション",
+		},
+		{
+			name:      "UUID session ID",
+			sessionID: "d423f0ad-9ba7-46e4-8afb-869f70a89fff",
+			turns:     10,
+			cost:      0.25,
+			want: "✅ セッション完了\n" +
+				"セッションID: `d423f0ad-9ba7-46e4-8afb-869f70a89fff`\n" +
+				"ターン数: 10\n" +
+				"コスト: $0.250000 USD",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatCompletionMessage(tt.sessionID, tt.turns, tt.cost)
+			if got != tt.want {
+				t.Errorf("FormatCompletionMessage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatErrorMessage(t *testing.T) {
+	tests := []struct {
+		name      string
+		sessionID string
+		want      string
+	}{
+		{
+			name:      "simple session ID",
+			sessionID: "session-123",
+			want:      "❌ セッションがエラーで終了しました\nセッションID: `session-123`",
+		},
+		{
+			name:      "UUID session ID",
+			sessionID: "d423f0ad-9ba7-46e4-8afb-869f70a89fff",
+			want:      "❌ セッションがエラーで終了しました\nセッションID: `d423f0ad-9ba7-46e4-8afb-869f70a89fff`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatErrorMessage(tt.sessionID)
+			if got != tt.want {
+				t.Errorf("FormatErrorMessage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFormatDuration(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/messages/format_test.go
+++ b/internal/messages/format_test.go
@@ -20,7 +20,7 @@ func TestFormatSessionStartMessage(t *testing.T) {
 			cwd:       "/home/user/project",
 			model:     "claude-3.5-sonnet",
 			want: "🚀 Claude Code セッション開始\n" +
-				"セッションID: session-123\n" +
+				"セッションID: `session-123`\n" +
 				"作業ディレクトリ: /home/user/project\n" +
 				"モデル: claude-3.5-sonnet",
 		},
@@ -30,7 +30,7 @@ func TestFormatSessionStartMessage(t *testing.T) {
 			cwd:       "/Users/name/My Documents/project",
 			model:     "claude-3.5-sonnet",
 			want: "🚀 Claude Code セッション開始\n" +
-				"セッションID: session-456\n" +
+				"セッションID: `session-456`\n" +
 				"作業ディレクトリ: /Users/name/My Documents/project\n" +
 				"モデル: claude-3.5-sonnet",
 		},
@@ -121,7 +121,7 @@ func TestFormatTimeoutMessage(t *testing.T) {
 			sessionID:   "session-123",
 			want: "⏰ セッションがタイムアウトしました\n" +
 				"アイドル時間: 15分\n" +
-				"セッションID: session-123\n\n" +
+				"セッションID: `session-123`\n\n" +
 				"新しいセッションを開始するには、再度メンションしてください。",
 		},
 		{
@@ -130,7 +130,7 @@ func TestFormatTimeoutMessage(t *testing.T) {
 			sessionID:   "session-456",
 			want: "⏰ セッションがタイムアウトしました\n" +
 				"アイドル時間: 120分\n" +
-				"セッションID: session-456\n\n" +
+				"セッションID: `session-456`\n\n" +
 				"新しいセッションを開始するには、再度メンションしてください。",
 		},
 	}

--- a/internal/slack/handler.go
+++ b/internal/slack/handler.go
@@ -270,7 +270,7 @@ func (h *Handler) handleAppMention(event *slackevents.AppMentionEvent) {
 	// Post initial response based on whether session was resumed
 	var initialMessage string
 	if resumed {
-		initialMessage = fmt.Sprintf("前回のセッション %s を再開します...", previousSessionID)
+		initialMessage = fmt.Sprintf("前回のセッション `%s` を再開します...", previousSessionID)
 	} else {
 		initialMessage = "Claude Code セッションを開始しています..."
 	}


### PR DESCRIPTION
## 概要

Slackメッセージ内のセッションIDをバッククォートで囲み、インラインコードとして表示するように変更しました。

## 変更内容

- セッション開始時: `セッションID: \`
- セッション完了時: `セッションID: \`
- セッション再開時: `前回のセッション \ を再開します...`
- タイムアウト時: `セッションID: \`
- エラー終了時: `セッションID: \`

## 変更ファイル

- `internal/messages/format.go`: フォーマット関数の更新
- `internal/slack/handler.go`: セッション再開メッセージの更新
- `internal/messages/format_test.go`: テストケースの期待値更新

## テスト

- 既存のテストが全て成功することを確認済み
- `go vet` によるチェックをパス
- `go mod tidy` 実行済み

## スクリーンショット

変更前:
> セッションID: d423f0ad-9ba7-46e4-8afb-869f70a89fff

変更後:
> セッションID: `d423f0ad-9ba7-46e4-8afb-869f70a89fff`

🤖 Generated with [Claude Code](https://claude.ai/code)