### PR TITLE
Remove Tailscale references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,9 @@ go build -o cc-slack cmd/cc-slack/main.go
 
 ### Exposing Local Development to Slack
 
-Since Slack requires HTTPS endpoints for webhooks, you need to expose your local cc-slack instance. We recommend using Tailscale Funnel:
+Since Slack requires HTTPS endpoints for webhooks, you need to expose your local cc-slack instance.
 
-#### Using Tailscale Funnel (Recommended)
-
-1. Enable Funnel in your Tailnet settings
-2. Run cc-slack locally (default port 8080)
-3. Expose it with Tailscale:
-   ```bash
-   tailscale funnel 8080
-   ```
-4. Use the provided `https://<machine-name>.<tailnet-name>.ts.net` URL for Slack webhook URLs
-
-#### Alternative: ngrok
+#### ngrok
 
 ```bash
 ngrok http 8080


### PR DESCRIPTION
## Summary
- Remove all Tailscale references from README.md
- Keep ngrok as the primary method for exposing local development to Slack

## Test plan
- [x] Verify README.md no longer contains any Tailscale references
- [x] Verify ngrok instructions remain clear and complete

🤖 Generated with [Claude Code](https://claude.ai/code)