### PR TITLE
docs: ドキュメントを最新の実装に合わせて更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,9 +216,14 @@ Claude Code Hooks automatically runs goimports, which removes unused imports. To
 - Add imports afterwards (or let goimports auto-add them)
 - When multiple imports are needed, write the code that uses them before organizing imports
 
-### Development Workflow with Restart
+### Development Workflow with Manager Scripts
 
-During development, use the cc-slack-manager for restarting cc-slack:
+During development, use the provided scripts for managing cc-slack:
+
+**Starting cc-slack-manager:**
+```bash
+./scripts/start
+```
 
 **To restart cc-slack when explicitly requested:**
 ```bash
@@ -346,9 +351,9 @@ When adding new features, always consider:
 - `internal/db/`: Database access layer (sqlc generated)
 - `internal/database/`: Database connection and migration utilities
 - `internal/config/`: Configuration management (Viper)
-- `internal/session/db_manager.go`: Session manager with database persistence
-- `internal/web/`: Web management console
-- `internal/workspace/`: Working directory management
+- `internal/session/`: Session manager with database persistence
+- `internal/messages/`: Slack message formatting utilities
+- `internal/tools/`: Claude Code tool information management
 - `migrations/`: Database schema migrations
 
 ## Logging
@@ -385,8 +390,10 @@ Logs are written to `logs/` directory with timestamp:
 - `CC_SLACK_SESSION_CLEANUP_INTERVAL`: Cleanup interval (default: 5m)
 - `CC_SLACK_SESSION_RESUME_WINDOW`: Resume window duration (default: 1h)
 
-**Working Directory Configuration:**
-- `CC_SLACK_WORKING_DIRECTORIES_DEFAULT`: Default working directory
+**Logging Configuration:**
+- `CC_SLACK_LOGGING_LEVEL`: Log level (default: info)
+- `CC_SLACK_LOGGING_FORMAT`: Log format (default: json)
+- `CC_SLACK_LOGGING_OUTPUT`: Log output directory (default: ./logs)
 
 **Note:** All environment variables can also be set in `config.yaml` file using Viper
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ export CC_SLACK_SLACK_BOT_TOKEN=xoxb-your-bot-token
 export CC_SLACK_SLACK_SIGNING_SECRET=your-signing-secret
 
 # Optional
-export CC_SLACK_PORT=8080                              # default: 8080
-export CC_SLACK_BASE_URL=http://localhost:8080         # default: http://localhost:8080
+export CC_SLACK_SERVER_PORT=8080                        # default: 8080
+export CC_SLACK_SERVER_BASE_URL=http://localhost:8080   # default: http://localhost:8080
+export CC_SLACK_DATABASE_PATH=./data/cc-slack.db        # default: ./data/cc-slack.db
+export CC_SLACK_SESSION_TIMEOUT=30m                     # default: 30m
+export CC_SLACK_SESSION_RESUME_WINDOW=1h                # default: 1h
 ```
 
 ### Build and Run
@@ -68,7 +71,7 @@ cc-slack runs an MCP server for approval prompts. Configure Claude Code to conne
 claude mcp add --transport http cc-slack http://localhost:8080/mcp
 
 # Or with custom base URL
-claude mcp add --transport http cc-slack ${CC_SLACK_BASE_URL}/mcp
+claude mcp add --transport http cc-slack ${CC_SLACK_SERVER_BASE_URL}/mcp
 ```
 
 ## Usage
@@ -84,6 +87,13 @@ claude mcp add --transport http cc-slack ${CC_SLACK_BASE_URL}/mcp
    ```
    add error handling please
    ```
+
+### Features
+
+- **Session Persistence**: Sessions are stored in SQLite database
+- **Session Resume**: Automatically resume previous sessions within the configured time window
+- **Isolated Sessions**: Each Slack thread gets its own Claude Code session
+- **Cost Tracking**: Track token usage and costs per session
 
 Note: Claude Code sessions use the current working directory where cc-slack is running.
 

--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -9,7 +9,7 @@
 2. **凝集性の向上** - 関連するロジックを同一ファイルに集約し、Claude Codeでの編集を容易に
 3. **純粋関数の抽出** - テスト可能なロジックを抽出し、ユニットテストを追加
 
-## フェーズ1: ツール表示情報の統一
+## フェーズ1: ツール表示情報の統一 ✅ **実装済み**
 
 ### 現状の問題
 - ツール名と絵文字のマッピングが複数ファイルに分散
@@ -17,17 +17,17 @@
   - `internal/session/manager.go`: `getToolEmoji()`
 
 ### 実装計画
-1. `internal/tools/display.go` を新規作成
-2. ツール情報を一元管理する構造体を定義：
+1. ✅ `internal/tools/display.go` を新規作成
+2. ✅ ツール情報を一元管理する構造体を定義：
    ```go
    type ToolInfo struct {
-       Name  string
-       Emoji string
-       Icon  string
+       Name      string
+       Emoji     string // Unicode emoji
+       SlackIcon string // Slack emoji code
    }
    ```
-3. 全ツール情報を定数として定義
-4. 既存コードを新しい構造体を使用するよう修正
+3. ✅ 全ツール情報を定数として定義
+4. ✅ 既存コードを新しい構造体を使用するよう修正
 
 ### 影響範囲
 - `internal/slack/handler.go`
@@ -35,19 +35,26 @@
 
 ## フェーズ2: 純粋関数の抽出とテスト追加
 
-### 2.1 メッセージフォーマット関数の抽出
+### 2.1 メッセージフォーマット関数の抽出 ✅ **実装済み**
 
 #### 実装計画
-1. `internal/messages/format.go` を新規作成
-2. 以下の関数を抽出：
+1. ✅ `internal/messages/format.go` を新規作成
+2. ✅ 以下の関数を抽出：
    - `FormatSessionStartMessage(sessionID, cwd, model string) string`
    - `FormatSessionCompleteMessage(duration time.Duration, turns int, cost float64, inputTokens, outputTokens int) string`
    - `FormatTimeoutMessage(idleMinutes int, sessionID string) string`
    - `FormatBashToolMessage(command string) string`
-   - `FormatReadToolMessage(filePath string) string`
+   - `FormatReadToolMessage(filePath string, offset, limit int) string`
    - `FormatGrepToolMessage(pattern, path string) string`
+   - `FormatEditToolMessage(filePath string) string`
+   - `FormatWriteToolMessage(filePath string) string`
+   - `FormatLSToolMessage(path string) string`
+   - `FormatGlobToolMessage(pattern string) string`
+   - `FormatTaskToolMessage(description, prompt string) string`
+   - `FormatWebFetchToolMessage(url, prompt string) string`
+   - `FormatDuration(d time.Duration) string`
 
-3. 各関数に対するユニットテストを `internal/messages/format_test.go` に追加
+3. ✅ 各関数に対するユニットテストを `internal/messages/format_test.go` に追加
 
 #### 影響範囲
 - `internal/session/manager.go` の巨大なswitch文をリファクタリング
@@ -147,8 +154,8 @@
 
 ## 実装順序
 
-1. **フェーズ2.1**: メッセージフォーマット関数の抽出（最も影響が少ない）
-2. **フェーズ1**: ツール表示情報の統一（依存関係が単純）
+1. ✅ **フェーズ2.1**: メッセージフォーマット関数の抽出（最も影響が少ない）
+2. ✅ **フェーズ1**: ツール表示情報の統一（依存関係が単純）
 3. **フェーズ2.2, 2.3**: その他の純粋関数の抽出
 4. **フェーズ4**: 共通ロジックの抽出
 5. **フェーズ3**: 凝集性の向上（最も影響が大きい）


### PR DESCRIPTION
## 概要
cc-slackのドキュメントが実装と乖離していた部分を修正し、最新の状態に更新しました。

## 変更内容

### CLAUDE.md
- 存在しないディレクトリ（, ）への参照を削除
- 新しく追加されたディレクトリ（, ）を追記
- 環境変数名を実装に合わせて修正
- Manager Scripts の使用方法を追記

### README.md
- 環境変数名を実装に合わせて修正（ など）
- Features セクションを追加し、主要機能を記載

### docs/design.md
- 環境変数セクションを最新の実装に合わせて更新
-  テーブルの定義を実装に合わせて修正
- 複数ワーキングディレクトリ対応の実装方針を更新

### docs/refactoring-plan.md
- 実装済みのフェーズ（フェーズ1とフェーズ2.1）に ✅ マークを追加
- 実装済みの関数名を実際の実装に合わせて更新

## テスト計画
ドキュメントのみの変更のため、機能テストは不要です。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>