### PR TITLE
セッション完了時の実行時間表示を復活

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -533,7 +533,9 @@ func (m *Manager) createResultHandler(channelID, threadTS, tempSessionID string)
 		if msg.IsError {
 			text = messages.FormatErrorMessage(msg.SessionID)
 		} else {
-			text = messages.FormatCompletionMessage(msg.SessionID, msg.NumTurns, msg.TotalCostUSD)
+			// Convert milliseconds to time.Duration
+			duration := time.Duration(msg.DurationMS) * time.Millisecond
+			text = messages.FormatSessionCompleteMessage(duration, msg.NumTurns, msg.TotalCostUSD, msg.Usage.InputTokens, msg.Usage.OutputTokens)
 		}
 
 		return m.slackHandler.PostToThread(channelID, threadTS, text)


### PR DESCRIPTION
## 概要
PR #8 で実装されていたセッション完了時の実行時間表示機能を復活させました。

## 変更内容
- セッション完了メッセージに実行時間を含めるように修正
-  の代わりに  を使用
- ミリ秒単位の実行時間を人間が読みやすい形式（例: 4分56秒）で表示
- トークン使用量の情報も含むように変更

## 技術的詳細
-  の  フィールドを  に変換
-  関数を使用（既存の実装を活用）
-  関数による日本語形式での時間表示（既にテスト済み）

## 動作確認
- [ ] セッション完了時に実行時間が日本語形式で表示される
- [ ] 1分未満の場合: XX秒
- [ ] 1時間未満の場合: XX分XX秒
- [ ] 1時間以上の場合: XX時間XX分XX秒
- [ ] トークン使用量が表示される

## 関連PR
- #8: 元の実装