### PR TITLE
feat: WebSearchツールの表示を改善

### DIFF
--- a/internal/messages/format.go
+++ b/internal/messages/format.go
@@ -127,6 +127,14 @@ func FormatWebFetchToolMessage(url, prompt string) string {
 	return fmt.Sprintf("Fetching: <%s>\n```\n%s\n```", url, escapedPrompt)
 }
 
+// FormatWebSearchToolMessage formats the WebSearch tool message
+func FormatWebSearchToolMessage(query string) string {
+	// Escape triple backticks in query
+	escapedQuery := strings.ReplaceAll(query, "```", "\\`\\`\\`")
+
+	return fmt.Sprintf("Searching web for: `%s`", escapedQuery)
+}
+
 // FormatCompletionMessage formats the completion message with session info
 func FormatCompletionMessage(sessionID string, turns int, cost float64) string {
 	text := fmt.Sprintf("✅ セッション完了\n"+

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -484,6 +484,15 @@ func (m *Manager) createAssistantHandler(channelID, threadTS string) func(proces
 					if err := m.slackHandler.PostToolMessage(channelID, threadTS, message, ccslack.ToolWebFetch); err != nil {
 						fmt.Printf("Failed to post WebFetch tool to Slack: %v\n", err)
 					}
+				} else if content.Name == "WebSearch" && content.Input != nil {
+					// Handle WebSearch tool
+					query, _ := content.Input["query"].(string)
+
+					message := messages.FormatWebSearchToolMessage(query)
+					// Post using tool-specific icon and username
+					if err := m.slackHandler.PostToolMessage(channelID, threadTS, message, ccslack.ToolWebSearch); err != nil {
+						fmt.Printf("Failed to post WebSearch tool to Slack: %v\n", err)
+					}
 				} else {
 					// Other tools - use tool-specific display or fallback
 					if err := m.slackHandler.PostToolMessage(channelID, threadTS, content.Name, content.Name); err != nil {


### PR DESCRIPTION
## Summary
- WebSearchツールのメッセージ表示を改善し、検索クエリを表示するようにしました
- 「WebSearch」だけではなく「Searching web for: `検索クエリ`」と表示されるようになります
- 他のツール（Bash、Task、WebFetch等）と同様の詳細な情報表示を実現

## Changes
- `FormatWebSearchToolMessage` 関数を追加して検索クエリをフォーマット
- `manager.go` にWebSearchツール専用の処理を追加
- クエリ内のバッククォートは適切にエスケープ処理

## Test Plan
- [x] Go のビルドが成功することを確認
- [x] 静的解析（go vet）でエラーがないことを確認
- [x] 全てのテストがパスすることを確認

## Related Issues
- Fixes #32

🤖 Generated with [Claude Code](https://claude.ai/code)