### PR TITLE
feat: Web管理コンソールにcc-slack再起動機能を追加

### DIFF
--- a/cmd/cc-slack-manager/main.go
+++ b/cmd/cc-slack-manager/main.go
@@ -30,7 +30,7 @@ type Manager struct {
 type StatusResponse struct {
 	Running bool      `json:"running"`
 	PID     int       `json:"pid,omitempty"`
-	Uptime  string    `json:"uptime,omitempty"`
+	Uptime  int64     `json:"uptime,omitempty"`
 	Started time.Time `json:"started,omitempty"`
 }
 
@@ -267,7 +267,7 @@ func (m *Manager) Status() StatusResponse {
 		Running: true,
 		PID:     m.cmd.Process.Pid,
 		Started: m.startTime,
-		Uptime:  time.Since(m.startTime).String(),
+		Uptime:  int64(time.Since(m.startTime).Seconds()),
 	}
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,6 +36,18 @@ function App() {
                 All Sessions
               </Link>
             </li>
+            <li>
+              <Link
+                to="/manager"
+                className={`text-lg ${
+                  location.pathname === "/web/manager"
+                    ? "text-blue-600 font-semibold"
+                    : "text-gray-600 hover:text-blue-600"
+                }`}
+              >
+                Manager
+              </Link>
+            </li>
           </ul>
         </nav>
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import App from "./App";
+import ManagerPage from "./pages/ManagerPage";
 import SessionsPage from "./pages/SessionsPage";
 import ThreadSessionsPage from "./pages/ThreadSessionsPage";
 import ThreadsPage from "./pages/ThreadsPage";
-import ManagerPage from "./pages/ManagerPage";
 import "../styles/index.css";
 
 const router = createBrowserRouter(

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -5,6 +5,7 @@ import App from "./App";
 import SessionsPage from "./pages/SessionsPage";
 import ThreadSessionsPage from "./pages/ThreadSessionsPage";
 import ThreadsPage from "./pages/ThreadsPage";
+import ManagerPage from "./pages/ManagerPage";
 import "../styles/index.css";
 
 const router = createBrowserRouter(
@@ -25,11 +26,15 @@ const router = createBrowserRouter(
           path: "threads/:threadId/sessions",
           element: <ThreadSessionsPage />,
         },
+        {
+          path: "manager",
+          element: <ManagerPage />,
+        },
       ],
     },
   ],
   {
-    basename: "/",
+    basename: "/web",
   },
 );
 

--- a/web/src/pages/ManagerPage.tsx
+++ b/web/src/pages/ManagerPage.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useState, useCallback, useRef } from "react";
+
+interface Status {
+  running: boolean;
+  pid?: number;
+  uptime?: string;
+  started?: string;
+}
+
+interface RestartResponse {
+  success: boolean;
+  error?: string;
+  pid?: number;
+  duration?: string;
+}
+
+function ManagerPage() {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [restarting, setRestarting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastRestartTime, setLastRestartTime] = useState<Date | null>(null);
+  const pollIntervalRef = useRef<number | null>(null);
+  const previousPidRef = useRef<number | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const response = await fetch("/api/manager/status");
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const data: Status = await response.json();
+      setStatus(data);
+      setError(null);
+      return data;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch status");
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const pollStatusUntilChanged = useCallback(async () => {
+    const startTime = Date.now();
+    const maxPollingTime = 30000; // 30 seconds max
+    const pollInterval = 500; // 500ms between polls
+
+    return new Promise<boolean>((resolve) => {
+      const poll = async () => {
+        const currentStatus = await fetchStatus();
+        
+        if (currentStatus && currentStatus.pid && currentStatus.pid !== previousPidRef.current) {
+          // PID changed, restart complete
+          resolve(true);
+          return;
+        }
+
+        if (Date.now() - startTime > maxPollingTime) {
+          // Timeout
+          resolve(false);
+          return;
+        }
+
+        // Continue polling
+        pollIntervalRef.current = window.setTimeout(poll, pollInterval);
+      };
+
+      poll();
+    });
+  }, [fetchStatus]);
+
+  const handleRestart = async () => {
+    setRestarting(true);
+    setError(null);
+
+    try {
+      // Store current PID before restart
+      if (status?.pid) {
+        previousPidRef.current = status.pid;
+      }
+
+      const response = await fetch("/api/manager/restart", {
+        method: "POST",
+      });
+
+      const data: RestartResponse = await response.json();
+
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || "Restart failed");
+      }
+
+      setLastRestartTime(new Date());
+      
+      // Poll for status change
+      const restartDetected = await pollStatusUntilChanged();
+      
+      if (restartDetected) {
+        // Force reload the browser
+        window.location.reload();
+      } else {
+        setError("Restart may have failed - timeout waiting for PID change");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to restart");
+    } finally {
+      setRestarting(false);
+    }
+  };
+
+  // Initial fetch
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  // Auto-refresh status every 5 seconds
+  useEffect(() => {
+    const interval = setInterval(fetchStatus, 5000);
+    return () => clearInterval(interval);
+  }, [fetchStatus]);
+
+  // Cleanup polling on unmount
+  useEffect(() => {
+    return () => {
+      if (pollIntervalRef.current) {
+        clearTimeout(pollIntervalRef.current);
+      }
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="text-gray-500">Loading...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <h2 className="text-2xl font-bold mb-6">cc-slack Manager</h2>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-6">
+          {error}
+        </div>
+      )}
+
+      <div className="bg-white shadow rounded-lg p-6 mb-6">
+        <h3 className="text-lg font-semibold mb-4">Status</h3>
+        
+        {status ? (
+          <div className="space-y-2">
+            <div className="flex items-center">
+              <span className="font-medium w-24">Status:</span>
+              <span className={`px-2 py-1 rounded text-sm ${
+                status.running 
+                  ? "bg-green-100 text-green-800" 
+                  : "bg-red-100 text-red-800"
+              }`}>
+                {status.running ? "Running" : "Stopped"}
+              </span>
+            </div>
+            
+            {status.running && status.pid && (
+              <>
+                <div className="flex items-center">
+                  <span className="font-medium w-24">PID:</span>
+                  <span className="text-gray-700">{status.pid}</span>
+                </div>
+                
+                {status.uptime && (
+                  <div className="flex items-center">
+                    <span className="font-medium w-24">Uptime:</span>
+                    <span className="text-gray-700">{status.uptime}</span>
+                  </div>
+                )}
+                
+                {status.started && (
+                  <div className="flex items-center">
+                    <span className="font-medium w-24">Started:</span>
+                    <span className="text-gray-700">
+                      {new Date(status.started).toLocaleString()}
+                    </span>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        ) : (
+          <div className="text-gray-500">Unable to fetch status</div>
+        )}
+      </div>
+
+      <div className="bg-white shadow rounded-lg p-6">
+        <h3 className="text-lg font-semibold mb-4">Actions</h3>
+        
+        <div className="space-y-4">
+          <button
+            onClick={handleRestart}
+            disabled={restarting || !status?.running}
+            className={`px-6 py-2 rounded font-medium transition-colors ${
+              restarting || !status?.running
+                ? "bg-gray-300 text-gray-500 cursor-not-allowed"
+                : "bg-blue-600 text-white hover:bg-blue-700"
+            }`}
+          >
+            {restarting ? "Restarting..." : "Restart cc-slack"}
+          </button>
+          
+          {lastRestartTime && (
+            <div className="text-sm text-gray-600">
+              Last restart: {lastRestartTime.toLocaleTimeString()}
+            </div>
+          )}
+          
+          {!status?.running && (
+            <div className="text-sm text-amber-600">
+              cc-slack is not running. Start it manually first.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ManagerPage;


### PR DESCRIPTION
## 概要
Web管理コンソールから cc-slack プロセスを再起動できる機能を追加しました。
これにより、SSHアクセスが困難な状況（モバイル環境など）でも、ブラウザから簡単に cc-slack を再起動できるようになります。

## 変更内容

### フロントエンド
- 新規ページ `ManagerPage` を追加（`/web/manager`でアクセス可能）
- cc-slack のステータス表示（Running/Stopped、PID、Uptime）
- 再起動ボタンの実装
- PID変化を検知して自動的にブラウザをリロードする機能

### バックエンド
- cc-slack に manager API へのプロキシエンドポイントを追加（`/api/manager/*`）
- cc-slack-manager に CORS ミドルウェアを追加
- プロキシ実装により CORS 問題を回避

### バグ修正
- **再起動時の「process already running」エラーを修正**
  - Stop() メソッドでプロセス停止後に `m.cmd = nil` を設定
  - ログファイルハンドルも適切にクリーンアップ
- **uptimeが常に0sになるバグを修正**
  - Manager構造体に `startTime` フィールドを追加
  - プロセス開始時刻を記録し、正確な稼働時間を計算
- **uptimeの型を整数（秒数）に変更**
  - フロントエンドでの処理を簡単にするため

## 技術的な詳細

### 再起動の流れ
1. ユーザーが「Restart cc-slack」ボタンをクリック
2. `/api/manager/restart` エンドポイントにPOSTリクエスト
3. cc-slack がリクエストを cc-slack-manager にプロキシ
4. cc-slack-manager が cc-slack プロセスを再起動
5. フロントエンドがポーリングでPID変化を検知
6. PID変化を検知したらブラウザを自動リロード

### なぜプロキシが必要か
- cc-slack-manager は localhost:10080 で動作
- Web コンソールは cc-slack 経由でアクセスされるため、直接 localhost:10080 にアクセスするとCORSエラーが発生
- cc-slack でプロキシすることで、同一オリジンからのリクエストとして扱われる

## テスト計画

### 前提条件
- [ ] cc-slack-manager が起動している（`./scripts/start`）
- [ ] cc-slack が cc-slack-manager 経由で起動している

### 機能テスト
- [ ] `/web/manager` にアクセスできることを確認
- [ ] ステータスが正しく表示されることを確認（Running、PID、Uptime）
- [ ] 「Restart cc-slack」ボタンをクリック
- [ ] 「Restarting...」の表示に変わることを確認
- [ ] 再起動完了後、ブラウザが自動的にリロードされることを確認
- [ ] リロード後、新しいPIDが表示されることを確認
- [ ] Uptimeが0秒にリセットされ、時間経過とともに増加することを確認
- [ ] ステータスが5秒ごとに自動更新されることを確認

### エラーケース
- [ ] cc-slack-manager が起動していない場合、エラーメッセージが表示されることを確認
- [ ] cc-slack が停止している場合、再起動ボタンが無効化されることを確認

### ビルドとテスト
- [ ] `./scripts/build` が正常に完了することを確認
- [ ] `go vet ./...` でエラーがないことを確認
- [ ] `go test ./...` でテストが通ることを確認
- [ ] `go mod tidy` で依存関係が整理されていることを確認

## スクリーンショット
（実際の画面のスクリーンショットを後で追加予定）

## 今後の改善案
- フロントエンドのuptime表示フォーマット（現在は秒数のまま）
- 再起動履歴の表示
- 停止・開始ボタンの追加
- ログ表示機能

🤖 Generated with Claude Code