### PR TITLE
fix(web): dynamically determine Router basename to prevent routing errors

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,6 +8,17 @@ import ThreadSessionsPage from "./pages/ThreadSessionsPage";
 import ThreadsPage from "./pages/ThreadsPage";
 import "../styles/index.css";
 
+// Dynamically determine basename based on current URL
+const getBasename = () => {
+  const pathname = window.location.pathname;
+  // If we're under /web, use /web as basename
+  if (pathname.startsWith("/web")) {
+    return "/web";
+  }
+  // Otherwise, use root
+  return "/";
+};
+
 const router = createBrowserRouter(
   [
     {
@@ -34,7 +45,7 @@ const router = createBrowserRouter(
     },
   ],
   {
-    basename: "/web",
+    basename: getBasename(),
   },
 );
 


### PR DESCRIPTION
## Summary
- Web管理コンソールでのRouterのbasename設定を動的に決定するように修正
- URLのパスから自動的にbasenameを検出し、ルーティングエラーを防止

## Test plan
- [x] Web管理コンソールが正常に表示されることを確認
- [ ] ルート以外のパス（例: /web/）でアクセスした場合も正しく動作することを確認
- [ ] ページのリロード時にルーティングエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)