### PR TITLE
feat(manager): build cc-slack before starting for development

### DIFF
--- a/cmd/cc-slack-manager/main.go
+++ b/cmd/cc-slack-manager/main.go
@@ -113,6 +113,17 @@ func (m *Manager) Start() error {
 	log.Printf("📁 Project root: %s", projectRoot)
 	log.Printf("📁 Executable path: %s", execPath)
 
+	// Build cc-slack before starting
+	log.Println("🔨 Building cc-slack...")
+	buildCmd := exec.Command("./scripts/build")
+	buildCmd.Dir = projectRoot
+	buildCmd.Stdout = os.Stdout
+	buildCmd.Stderr = os.Stderr
+
+	if err := buildCmd.Run(); err != nil {
+		return fmt.Errorf("failed to build cc-slack: %w", err)
+	}
+
 	cmd := exec.CommandContext(m.ctx, "./cc-slack")
 	cmd.Dir = projectRoot // Set working directory to project root
 
@@ -172,7 +183,6 @@ func (m *Manager) Stop() error {
 	log.Printf("🔄 Stopping cc-slack (PID: %d)...", m.cmd.Process.Pid)
 
 	// Try graceful shutdown first
-	// Note: When using 'go run', we need to send signal to the process group
 	pgid, err := syscall.Getpgid(m.cmd.Process.Pid)
 	if err == nil {
 		// Send signal to the entire process group


### PR DESCRIPTION
## Summary
- cc-slack-managerで起動前に`./scripts/build`を実行するように変更
- フロントエンドとバックエンドの両方が最新の変更でビルドされることを保証
- 再起動時にビルドプロセスが自動化され、開発ワークフローが簡素化

## Test plan
- [ ] cc-slack-managerを起動
- [ ] cc-slackのコード（フロントエンド/バックエンド）を変更
- [ ] 管理コンソールから再起動を実行
- [ ] 変更が反映されることを確認