### PR TITLE
feat: mention initiator when starting session from modal

### DIFF
--- a/internal/slack/handler.go
+++ b/internal/slack/handler.go
@@ -146,7 +146,8 @@ func (h *Handler) determineWorkDir(channelID string) string {
 func (h *Handler) createThreadAndStartSession(channelID, workDir, prompt, userID string) {
 	// Create initial message with working directory information
 	var initialText strings.Builder
-	initialText.WriteString(fmt.Sprintf("🚀 Starting Claude Code session\n<@%s>", userID))
+	initialText.WriteString("🚀 Starting Claude Code session\n")
+	initialText.WriteString(fmt.Sprintf("\n👤 Initiator: <@%s>", userID))
 
 	// Add working directory info
 	if workDir != "" {

--- a/internal/slack/handler.go
+++ b/internal/slack/handler.go
@@ -142,38 +142,45 @@ func (h *Handler) determineWorkDir(channelID string) string {
 	return ""
 }
 
+// formatWorkingDirectory formats the working directory for display in messages
+func (h *Handler) formatWorkingDirectory(workDir string) string {
+	if workDir == "" {
+		return ""
+	}
+
+	// In single directory mode, show only the directory name
+	if h.config.IsSingleDirectoryMode() {
+		return fmt.Sprintf("\nWorking directory: `%s`", filepath.Base(workDir))
+	}
+
+	// In multi directory mode, find the name from config
+	dirName := ""
+	for _, wd := range h.config.WorkingDirs {
+		if wd.Path == workDir {
+			dirName = wd.Name
+			break
+		}
+	}
+
+	if dirName != "" {
+		return fmt.Sprintf("\nWorking directory: %s (`%s`)", dirName, workDir)
+	}
+	return fmt.Sprintf("\nWorking directory: `%s`", workDir)
+}
+
 // createThreadAndStartSession creates a new Slack thread and starts a Claude session
 func (h *Handler) createThreadAndStartSession(channelID, workDir, prompt, userID string) {
 	// Create initial message with working directory information
 	var initialText strings.Builder
-	initialText.WriteString("🚀 Starting Claude Code session\n")
-	initialText.WriteString(fmt.Sprintf("\n👤 Initiator: <@%s>", userID))
+	initialText.WriteString("🚀 Starting Claude Code session")
+	initialText.WriteString(fmt.Sprintf("\nInitiator: <@%s>", userID))
 
 	// Add working directory info
-	if workDir != "" {
-		// In single directory mode, show only the directory name
-		if h.config.IsSingleDirectoryMode() {
-			initialText.WriteString(fmt.Sprintf("\n📁 Working directory: `%s`", filepath.Base(workDir)))
-		} else {
-			// In multi directory mode, find the name from config
-			dirName := ""
-			for _, wd := range h.config.WorkingDirs {
-				if wd.Path == workDir {
-					dirName = wd.Name
-					break
-				}
-			}
-			if dirName != "" {
-				initialText.WriteString(fmt.Sprintf("\n📁 Working directory: %s (`%s`)", dirName, workDir))
-			} else {
-				initialText.WriteString(fmt.Sprintf("\n📁 Working directory: `%s`", workDir))
-			}
-		}
-	}
+	initialText.WriteString(h.formatWorkingDirectory(workDir))
 
 	// Add initial prompt if provided
 	if prompt != "" {
-		initialText.WriteString("\n💬 Initial prompt:\n")
+		initialText.WriteString("\nInitial prompt:\n")
 		initialText.WriteString(prompt)
 	}
 

--- a/internal/slack/handler.go
+++ b/internal/slack/handler.go
@@ -146,7 +146,7 @@ func (h *Handler) determineWorkDir(channelID string) string {
 func (h *Handler) createThreadAndStartSession(channelID, workDir, prompt, userID string) {
 	// Create initial message with working directory information
 	var initialText strings.Builder
-	initialText.WriteString("🚀 Starting Claude Code session\n")
+	initialText.WriteString(fmt.Sprintf("🚀 Starting Claude Code session\n<@%s>", userID))
 
 	// Add working directory info
 	if workDir != "" {

--- a/internal/slack/message_handler.go
+++ b/internal/slack/message_handler.go
@@ -212,59 +212,23 @@ func (h *Handler) handleNewSessionFromMessage(event *slackevents.MessageEvent, t
 	// Post initial response based on whether session was resumed
 	var initialMessage strings.Builder
 	if resumed {
-		initialMessage.WriteString("🔄 Resuming Claude Code session\n")
-		initialMessage.WriteString(fmt.Sprintf("\n👤 Initiator: <@%s>", event.User))
+		initialMessage.WriteString("🔄 Resuming Claude Code session")
+		initialMessage.WriteString(fmt.Sprintf("\nInitiator: <@%s>", event.User))
 
 		// Add working directory info if available
-		if workDir != "" {
-			if h.config.IsSingleDirectoryMode() {
-				initialMessage.WriteString(fmt.Sprintf("\n📁 Working directory: `%s`", filepath.Base(workDir)))
-			} else {
-				// In multi directory mode, find the name from config
-				dirName := ""
-				for _, wd := range h.config.WorkingDirs {
-					if wd.Path == workDir {
-						dirName = wd.Name
-						break
-					}
-				}
-				if dirName != "" {
-					initialMessage.WriteString(fmt.Sprintf("\n📁 Working directory: %s (`%s`)", dirName, workDir))
-				} else {
-					initialMessage.WriteString(fmt.Sprintf("\n📁 Working directory: `%s`", workDir))
-				}
-			}
-		}
+		initialMessage.WriteString(h.formatWorkingDirectory(workDir))
 
-		initialMessage.WriteString(fmt.Sprintf("\n🆔 Previous session: `%s`", previousSessionID))
+		initialMessage.WriteString(fmt.Sprintf("\nPrevious session: `%s`", previousSessionID))
 	} else {
-		initialMessage.WriteString("🚀 Starting Claude Code session\n")
-		initialMessage.WriteString(fmt.Sprintf("\n👤 Initiator: <@%s>", event.User))
+		initialMessage.WriteString("🚀 Starting Claude Code session")
+		initialMessage.WriteString(fmt.Sprintf("\nInitiator: <@%s>", event.User))
 
 		// Add working directory info if available
-		if workDir != "" {
-			if h.config.IsSingleDirectoryMode() {
-				initialMessage.WriteString(fmt.Sprintf("\n📁 Working directory: `%s`", filepath.Base(workDir)))
-			} else {
-				// In multi directory mode, find the name from config
-				dirName := ""
-				for _, wd := range h.config.WorkingDirs {
-					if wd.Path == workDir {
-						dirName = wd.Name
-						break
-					}
-				}
-				if dirName != "" {
-					initialMessage.WriteString(fmt.Sprintf("\n📁 Working directory: %s (`%s`)", dirName, workDir))
-				} else {
-					initialMessage.WriteString(fmt.Sprintf("\n📁 Working directory: `%s`", workDir))
-				}
-			}
-		}
+		initialMessage.WriteString(h.formatWorkingDirectory(workDir))
 
 		// Add initial prompt if provided (only show if there's actual content beyond image paths)
 		if text != "" && !strings.Contains(text, "# Images attached with the message") {
-			initialMessage.WriteString("\n💬 Initial prompt:\n")
+			initialMessage.WriteString("\nInitial prompt:\n")
 			initialMessage.WriteString(text)
 		}
 	}

--- a/internal/slack/message_handler.go
+++ b/internal/slack/message_handler.go
@@ -210,16 +210,68 @@ func (h *Handler) handleNewSessionFromMessage(event *slackevents.MessageEvent, t
 	}
 
 	// Post initial response based on whether session was resumed
-	var initialMessage string
+	var initialMessage strings.Builder
 	if resumed {
-		initialMessage = fmt.Sprintf("Resuming previous session `%s`...", previousSessionID)
+		initialMessage.WriteString("🔄 Resuming Claude Code session\n")
+		initialMessage.WriteString(fmt.Sprintf("\n👤 Initiator: <@%s>", event.User))
+
+		// Add working directory info if available
+		if workDir != "" {
+			if h.config.IsSingleDirectoryMode() {
+				initialMessage.WriteString(fmt.Sprintf("\n📁 Working directory: `%s`", filepath.Base(workDir)))
+			} else {
+				// In multi directory mode, find the name from config
+				dirName := ""
+				for _, wd := range h.config.WorkingDirs {
+					if wd.Path == workDir {
+						dirName = wd.Name
+						break
+					}
+				}
+				if dirName != "" {
+					initialMessage.WriteString(fmt.Sprintf("\n📁 Working directory: %s (`%s`)", dirName, workDir))
+				} else {
+					initialMessage.WriteString(fmt.Sprintf("\n📁 Working directory: `%s`", workDir))
+				}
+			}
+		}
+
+		initialMessage.WriteString(fmt.Sprintf("\n🆔 Previous session: `%s`", previousSessionID))
 	} else {
-		initialMessage = "🚀 Starting Claude Code session..."
+		initialMessage.WriteString("🚀 Starting Claude Code session\n")
+		initialMessage.WriteString(fmt.Sprintf("\n👤 Initiator: <@%s>", event.User))
+
+		// Add working directory info if available
+		if workDir != "" {
+			if h.config.IsSingleDirectoryMode() {
+				initialMessage.WriteString(fmt.Sprintf("\n📁 Working directory: `%s`", filepath.Base(workDir)))
+			} else {
+				// In multi directory mode, find the name from config
+				dirName := ""
+				for _, wd := range h.config.WorkingDirs {
+					if wd.Path == workDir {
+						dirName = wd.Name
+						break
+					}
+				}
+				if dirName != "" {
+					initialMessage.WriteString(fmt.Sprintf("\n📁 Working directory: %s (`%s`)", dirName, workDir))
+				} else {
+					initialMessage.WriteString(fmt.Sprintf("\n📁 Working directory: `%s`", workDir))
+				}
+			}
+		}
+
+		// Add initial prompt if provided (only show if there's actual content beyond image paths)
+		if text != "" && !strings.Contains(text, "# Images attached with the message") {
+			initialMessage.WriteString("\n💬 Initial prompt:\n")
+			initialMessage.WriteString(text)
+		}
 	}
 
 	_, _, err = h.client.PostMessage(
 		event.Channel,
-		slack.MsgOptionText(initialMessage, false),
+		slack.MsgOptionText(initialMessage.String(), false),
 		slack.MsgOptionTS(threadTS),
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Unify session start/resume message format across all initiation methods
- Add initiator mention to all session start messages
- Use consistent emoji bullets for better visual organization

## Changes

### Modal-initiated sessions
- Add `👤 Initiator: @username` to the message
- Format matches other fields with emoji bullets

### Mention-initiated sessions
**New session:**
```
🚀 Starting Claude Code session

👤 Initiator: @username
📁 Working directory: <directory>
💬 Initial prompt: <text>
```

**Resumed session:**
```
🔄 Resuming Claude Code session

👤 Initiator: @username
📁 Working directory: <directory>
🆔 Previous session: <session-id>
```

## Test plan
- [ ] Modal submission: Verify initiator mention appears with proper formatting
- [ ] New mention in channel: Verify formatted message with initiator and working directory
- [ ] New mention in thread: Verify resumed session shows all fields correctly
- [ ] Multi-directory mode: Verify directory names are shown correctly
- [ ] Single-directory mode: Verify only directory basename is shown