### PR TITLE
fix: preserve current route on page reload instead of redirecting to root

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,46 +8,30 @@ import ThreadSessionsPage from "./pages/ThreadSessionsPage";
 import ThreadsPage from "./pages/ThreadsPage";
 import "../styles/index.css";
 
-// Dynamically determine basename based on current URL
-const getBasename = () => {
-  const pathname = window.location.pathname;
-  // If we're under /web, use /web as basename
-  if (pathname.startsWith("/web")) {
-    return "/web";
-  }
-  // Otherwise, use root
-  return "/";
-};
-
-const router = createBrowserRouter(
-  [
-    {
-      path: "/",
-      element: <App />,
-      children: [
-        {
-          index: true,
-          element: <ThreadsPage />,
-        },
-        {
-          path: "sessions",
-          element: <SessionsPage />,
-        },
-        {
-          path: "threads/:threadId/sessions",
-          element: <ThreadSessionsPage />,
-        },
-        {
-          path: "manager",
-          element: <ManagerPage />,
-        },
-      ],
-    },
-  ],
+const router = createBrowserRouter([
   {
-    basename: getBasename(),
+    path: "/",
+    element: <App />,
+    children: [
+      {
+        index: true,
+        element: <ThreadsPage />,
+      },
+      {
+        path: "sessions",
+        element: <SessionsPage />,
+      },
+      {
+        path: "threads/:threadId/sessions",
+        element: <ThreadSessionsPage />,
+      },
+      {
+        path: "manager",
+        element: <ManagerPage />,
+      },
+    ],
   },
-);
+]);
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary

- Fixed SPA routing issue where reloading any page other than root would redirect to `/`
- Removed dynamic basename logic from React app that was causing routing conflicts
- Updated Go server to serve `index.html` without modifying the request path

## Problem

When navigating to routes like `/sessions` or `/threads/{threadId}/sessions` and reloading the page (F5), users were redirected to the root page `/`. This broke the user experience and made it impossible to refresh the current view.

## Solution

The issue was caused by two problems:
1. React app had dynamic basename logic that conflicted with server routing
2. Go server was modifying the request path to `/index.html`, preventing React Router from seeing the original path

Fixed by:
1. Removing the dynamic basename logic - always use `/` as basename
2. Serving `index.html` directly without changing `r.URL.Path`, allowing React Router to handle client-side routing based on the original URL

## Testing

- ✅ Navigate to `/sessions` and reload - stays on sessions page
- ✅ Navigate to `/threads/{threadId}/sessions` and reload - stays on thread sessions page
- ✅ Browser back/forward navigation works correctly
- ✅ API routes (`/api/*`) are not affected

Fixes #58