### PR TITLE
feat: add clickable link from sessions list to thread detail view

### DIFF
--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { formatDateRange, formatDuration } from "../utils/dateFormatter";
 import {
   getSessionStatusColor,
@@ -80,7 +81,13 @@ function SessionList() {
                     ID: {truncateSessionId(session.session_id)}
                   </p>
                   <p className="text-sm text-gray-500">
-                    Thread: {session.thread_ts}
+                    Thread:{" "}
+                    <Link
+                      to={`/threads/${session.thread_ts}/sessions`}
+                      className="text-blue-600 hover:text-blue-800 hover:underline"
+                    >
+                      {session.thread_ts}
+                    </Link>
                   </p>
                   <p className="text-sm text-gray-500">
                     {formatDateRange(session.started_at, session.ended_at, {


### PR DESCRIPTION
## Summary
- Added clickable links to thread IDs in the sessions list view
- Users can now navigate directly from a session to its parent thread view

## Changes
- Import `Link` component from react-router-dom in SessionList
- Convert thread ID from plain text to a clickable link that navigates to `/threads/{thread_id}/sessions`
- Applied consistent link styling (blue color with hover effects)

## Benefits
- Improved navigation between related views
- Better user experience when exploring session-thread relationships
- Reduces clicks needed to view thread context
- More intuitive interface

Closes #59