### PR TITLE
feat: add pagination to Web Console threads and sessions lists

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -21,7 +21,10 @@ type Querier interface {
 	ListActiveSessions(ctx context.Context) ([]Session, error)
 	ListSessions(ctx context.Context) ([]Session, error)
 	ListSessionsByThreadID(ctx context.Context, threadID int64) ([]Session, error)
+	ListSessionsByThreadIDPaginated(ctx context.Context, arg ListSessionsByThreadIDPaginatedParams) ([]Session, error)
+	ListSessionsPaginated(ctx context.Context, arg ListSessionsPaginatedParams) ([]Session, error)
 	ListThreads(ctx context.Context) ([]Thread, error)
+	ListThreadsPaginated(ctx context.Context, arg ListThreadsPaginatedParams) ([]Thread, error)
 	UpdateSessionEndTime(ctx context.Context, arg UpdateSessionEndTimeParams) error
 	UpdateSessionID(ctx context.Context, arg UpdateSessionIDParams) error
 	UpdateSessionModel(ctx context.Context, arg UpdateSessionModelParams) error

--- a/internal/db/queries/sessions.sql
+++ b/internal/db/queries/sessions.sql
@@ -83,3 +83,14 @@ ORDER BY started_at DESC;
 SELECT * FROM sessions
 WHERE thread_id = ?
 ORDER BY started_at DESC;
+
+-- name: ListSessionsPaginated :many
+SELECT * FROM sessions
+ORDER BY started_at DESC
+LIMIT ? OFFSET ?;
+
+-- name: ListSessionsByThreadIDPaginated :many
+SELECT * FROM sessions
+WHERE thread_id = ?
+ORDER BY started_at DESC
+LIMIT ? OFFSET ?;

--- a/internal/db/queries/threads.sql
+++ b/internal/db/queries/threads.sql
@@ -29,3 +29,8 @@ ORDER BY updated_at DESC;
 SELECT * FROM threads
 WHERE thread_ts = ?
 LIMIT 1;
+
+-- name: ListThreadsPaginated :many
+SELECT * FROM threads
+ORDER BY updated_at DESC
+LIMIT ? OFFSET ?;

--- a/internal/db/sessions.sql.go
+++ b/internal/db/sessions.sql.go
@@ -280,6 +280,104 @@ func (q *Queries) ListSessionsByThreadID(ctx context.Context, threadID int64) ([
 	return items, nil
 }
 
+const listSessionsByThreadIDPaginated = `-- name: ListSessionsByThreadIDPaginated :many
+SELECT id, thread_id, session_id, started_at, ended_at, status, model, total_cost_usd, input_tokens, output_tokens, duration_ms, num_turns, initial_prompt FROM sessions
+WHERE thread_id = ?
+ORDER BY started_at DESC
+LIMIT ? OFFSET ?
+`
+
+type ListSessionsByThreadIDPaginatedParams struct {
+	ThreadID int64 `json:"thread_id"`
+	Limit    int64 `json:"limit"`
+	Offset   int64 `json:"offset"`
+}
+
+func (q *Queries) ListSessionsByThreadIDPaginated(ctx context.Context, arg ListSessionsByThreadIDPaginatedParams) ([]Session, error) {
+	rows, err := q.query(ctx, q.listSessionsByThreadIDPaginatedStmt, listSessionsByThreadIDPaginated, arg.ThreadID, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Session
+	for rows.Next() {
+		var i Session
+		if err := rows.Scan(
+			&i.ID,
+			&i.ThreadID,
+			&i.SessionID,
+			&i.StartedAt,
+			&i.EndedAt,
+			&i.Status,
+			&i.Model,
+			&i.TotalCostUsd,
+			&i.InputTokens,
+			&i.OutputTokens,
+			&i.DurationMs,
+			&i.NumTurns,
+			&i.InitialPrompt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listSessionsPaginated = `-- name: ListSessionsPaginated :many
+SELECT id, thread_id, session_id, started_at, ended_at, status, model, total_cost_usd, input_tokens, output_tokens, duration_ms, num_turns, initial_prompt FROM sessions
+ORDER BY started_at DESC
+LIMIT ? OFFSET ?
+`
+
+type ListSessionsPaginatedParams struct {
+	Limit  int64 `json:"limit"`
+	Offset int64 `json:"offset"`
+}
+
+func (q *Queries) ListSessionsPaginated(ctx context.Context, arg ListSessionsPaginatedParams) ([]Session, error) {
+	rows, err := q.query(ctx, q.listSessionsPaginatedStmt, listSessionsPaginated, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Session
+	for rows.Next() {
+		var i Session
+		if err := rows.Scan(
+			&i.ID,
+			&i.ThreadID,
+			&i.SessionID,
+			&i.StartedAt,
+			&i.EndedAt,
+			&i.Status,
+			&i.Model,
+			&i.TotalCostUsd,
+			&i.InputTokens,
+			&i.OutputTokens,
+			&i.DurationMs,
+			&i.NumTurns,
+			&i.InitialPrompt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateSessionEndTime = `-- name: UpdateSessionEndTime :exec
 UPDATE sessions
 SET status = ?,

--- a/internal/db/threads.sql.go
+++ b/internal/db/threads.sql.go
@@ -138,6 +138,47 @@ func (q *Queries) ListThreads(ctx context.Context) ([]Thread, error) {
 	return items, nil
 }
 
+const listThreadsPaginated = `-- name: ListThreadsPaginated :many
+SELECT id, channel_id, thread_ts, working_directory, created_at, updated_at FROM threads
+ORDER BY updated_at DESC
+LIMIT ? OFFSET ?
+`
+
+type ListThreadsPaginatedParams struct {
+	Limit  int64 `json:"limit"`
+	Offset int64 `json:"offset"`
+}
+
+func (q *Queries) ListThreadsPaginated(ctx context.Context, arg ListThreadsPaginatedParams) ([]Thread, error) {
+	rows, err := q.query(ctx, q.listThreadsPaginatedStmt, listThreadsPaginated, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Thread
+	for rows.Next() {
+		var i Thread
+		if err := rows.Scan(
+			&i.ID,
+			&i.ChannelID,
+			&i.ThreadTs,
+			&i.WorkingDirectory,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateThreadTimestamp = `-- name: UpdateThreadTimestamp :exec
 UPDATE threads
 SET updated_at = CURRENT_TIMESTAMP

--- a/migrations/000008_add_pagination_indexes.down.sql
+++ b/migrations/000008_add_pagination_indexes.down.sql
@@ -1,0 +1,4 @@
+-- Drop pagination indexes
+DROP INDEX IF EXISTS idx_threads_updated_at_desc;
+DROP INDEX IF EXISTS idx_sessions_started_at_desc;
+DROP INDEX IF EXISTS idx_sessions_thread_started_at;

--- a/migrations/000008_add_pagination_indexes.up.sql
+++ b/migrations/000008_add_pagination_indexes.up.sql
@@ -1,0 +1,9 @@
+-- Indexes for pagination performance
+-- Threads pagination (ORDER BY updated_at DESC)
+CREATE INDEX IF NOT EXISTS idx_threads_updated_at_desc ON threads(updated_at DESC);
+
+-- Sessions pagination (ORDER BY started_at DESC)
+CREATE INDEX IF NOT EXISTS idx_sessions_started_at_desc ON sessions(started_at DESC);
+
+-- Sessions by thread pagination (thread_id filter + ORDER BY started_at DESC)
+CREATE INDEX IF NOT EXISTS idx_sessions_thread_started_at ON sessions(thread_id, started_at DESC);

--- a/web/src/components/ThreadList.tsx
+++ b/web/src/components/ThreadList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { buildSlackThreadUrl } from "../utils/slackUtils";
 
 interface Thread {
@@ -14,21 +14,28 @@ interface Thread {
 
 interface ThreadsResponse {
   threads: Thread[];
+  has_more: boolean;
+  page: number;
 }
 
 function ThreadList() {
   const [threads, setThreads] = useState<Thread[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPage = parseInt(searchParams.get("page") || "1", 10);
 
-  const fetchThreads = async () => {
+  const fetchThreads = async (page: number) => {
     try {
-      const response = await fetch("/api/threads");
+      setLoading(true);
+      const response = await fetch(`/api/threads?page=${page}`);
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
       const data: ThreadsResponse = await response.json();
       setThreads(data.threads || []);
+      setHasMore(data.has_more || false);
     } catch (err) {
       setError(err instanceof Error ? err.message : "An error occurred");
     } finally {
@@ -36,10 +43,19 @@ function ThreadList() {
     }
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: fetchThreads should only run on mount
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fetchThreads depends on currentPage
   useEffect(() => {
-    fetchThreads();
-  }, []);
+    fetchThreads(currentPage);
+  }, [currentPage]);
+
+  const goToPage = (page: number) => {
+    if (page === 1) {
+      searchParams.delete("page");
+    } else {
+      searchParams.set("page", page.toString());
+    }
+    setSearchParams(searchParams);
+  };
 
   if (loading) {
     return (
@@ -57,9 +73,40 @@ function ThreadList() {
     );
   }
 
+  const PaginationControls = () => (
+    <div className="flex justify-between items-center py-3">
+      <button
+        type="button"
+        onClick={() => goToPage(currentPage - 1)}
+        disabled={currentPage === 1}
+        className={`px-4 py-2 text-sm font-medium rounded-md ${
+          currentPage === 1
+            ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+            : "bg-white text-gray-700 hover:bg-gray-50 border border-gray-300"
+        }`}
+      >
+        ← Previous
+      </button>
+      <span className="text-sm text-gray-700">Page {currentPage}</span>
+      <button
+        type="button"
+        onClick={() => goToPage(currentPage + 1)}
+        disabled={!hasMore}
+        className={`px-4 py-2 text-sm font-medium rounded-md ${
+          !hasMore
+            ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+            : "bg-white text-gray-700 hover:bg-gray-50 border border-gray-300"
+        }`}
+      >
+        Next →
+      </button>
+    </div>
+  );
+
   return (
     <div>
       <h2 className="text-xl font-semibold text-gray-900 mb-4">Threads</h2>
+      {threads.length > 0 && <PaginationControls />}
       <div className="space-y-4">
         {threads.length === 0 ? (
           <div className="bg-white shadow rounded-lg p-6">
@@ -119,6 +166,7 @@ function ThreadList() {
           ))
         )}
       </div>
+      {threads.length > 0 && <PaginationControls />}
     </div>
   );
 }

--- a/web/src/pages/ThreadSessionsPage.tsx
+++ b/web/src/pages/ThreadSessionsPage.tsx
@@ -30,23 +30,25 @@ function ThreadSessionsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchThreadSessions = async () => {
-      try {
-        const response = await fetch(`/api/threads/${threadId}/sessions`);
-        if (!response.ok) {
-          throw new Error("Failed to fetch thread sessions");
-        }
-        const data: ThreadSessionsResponse = await response.json();
-        setThread(data.thread);
-        setSessions(data.sessions);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "An error occurred");
-      } finally {
-        setLoading(false);
+  const fetchThreadSessions = async () => {
+    try {
+      setLoading(true);
+      const response = await fetch(`/api/threads/${threadId}/sessions`);
+      if (!response.ok) {
+        throw new Error("Failed to fetch thread sessions");
       }
-    };
+      const data: ThreadSessionsResponse = await response.json();
+      setThread(data.thread);
+      setSessions(data.sessions);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fetchThreadSessions is not memoized
+  useEffect(() => {
     fetchThreadSessions();
   }, [threadId]);
 


### PR DESCRIPTION
## Summary
- Implemented pagination for Web Console threads and sessions lists to handle large datasets
- Added database indexes for optimal pagination performance
- Thread-specific sessions remain unpaginated as they typically have fewer items

## Changes
### Backend
- Added paginated SQL queries (`ListThreadsPaginated`, `ListSessionsPaginated`)
- Updated API endpoints to support `?page=N` query parameter
- API responses now include `has_more` and `page` fields
- Fetches 51 items to determine if next page exists

### Frontend
- Updated `ThreadList` and `SessionList` components with pagination
- Added Prev/Next navigation buttons (top and bottom)
- URL state management for page numbers
- Clean URLs (page 1 has no query param)

### Database
- Migration `000008_add_pagination_indexes` adds indexes:
  - `idx_threads_updated_at_desc`
  - `idx_sessions_started_at_desc`
  - `idx_sessions_thread_started_at`

### Implementation Details
- 50 items per page
- 1-indexed page numbers
- No total page count calculation
- Thread-specific sessions (`/threads/{threadId}/sessions`) remain unpaginated

## Testing
- [x] Frontend builds successfully
- [x] All tests pass (`pnpm all`)
- [x] Manual testing of pagination navigation

Closes #55