### PR TITLE
feat: display initial prompt in threads list

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -24,7 +24,7 @@ type Querier interface {
 	ListSessionsByThreadIDPaginated(ctx context.Context, arg ListSessionsByThreadIDPaginatedParams) ([]Session, error)
 	ListSessionsPaginated(ctx context.Context, arg ListSessionsPaginatedParams) ([]Session, error)
 	ListThreads(ctx context.Context) ([]Thread, error)
-	ListThreadsPaginated(ctx context.Context, arg ListThreadsPaginatedParams) ([]Thread, error)
+	ListThreadsPaginated(ctx context.Context, arg ListThreadsPaginatedParams) ([]ListThreadsPaginatedRow, error)
 	UpdateSessionEndTime(ctx context.Context, arg UpdateSessionEndTimeParams) error
 	UpdateSessionID(ctx context.Context, arg UpdateSessionIDParams) error
 	UpdateSessionModel(ctx context.Context, arg UpdateSessionModelParams) error

--- a/internal/db/queries/threads.sql
+++ b/internal/db/queries/threads.sql
@@ -31,6 +31,16 @@ WHERE thread_ts = ?
 LIMIT 1;
 
 -- name: ListThreadsPaginated :many
-SELECT * FROM threads
-ORDER BY updated_at DESC
+SELECT 
+    t.*,
+    s.initial_prompt AS first_session_prompt
+FROM threads t
+LEFT JOIN (
+    SELECT 
+        thread_id,
+        initial_prompt,
+        ROW_NUMBER() OVER (PARTITION BY thread_id ORDER BY started_at ASC) as rn
+    FROM sessions
+) s ON t.id = s.thread_id AND s.rn = 1
+ORDER BY t.updated_at DESC
 LIMIT ? OFFSET ?;

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -40,6 +40,7 @@ type ThreadResponse struct {
 	WorkspaceSubdomain  string `json:"workspace_subdomain"`
 	SessionCount        int    `json:"session_count"`
 	LatestSessionStatus string `json:"latest_session_status"`
+	InitialPrompt       string `json:"initial_prompt,omitempty"`
 }
 
 // ThreadsResponse represents the threads API response
@@ -133,7 +134,7 @@ func GetThreads(w http.ResponseWriter, r *http.Request) {
 			channelName = channelCache.GetChannelName(ctx, thread.ChannelID)
 		}
 
-		response.Threads = append(response.Threads, ThreadResponse{
+		threadResp := ThreadResponse{
 			ThreadTs:            thread.ThreadTs,
 			ThreadTime:          FormatThreadTime(threadTime),
 			ChannelID:           thread.ChannelID,
@@ -141,7 +142,14 @@ func GetThreads(w http.ResponseWriter, r *http.Request) {
 			WorkspaceSubdomain:  config.SLACK_WORKSPACE_SUBDOMAIN,
 			SessionCount:        sessionCount,
 			LatestSessionStatus: latestStatus,
-		})
+		}
+
+		// Add initial prompt if available
+		if thread.FirstSessionPrompt.Valid {
+			threadResp.InitialPrompt = thread.FirstSessionPrompt.String
+		}
+
+		response.Threads = append(response.Threads, threadResp)
 	}
 
 	// Return JSON response

--- a/web/src/components/ThreadList.tsx
+++ b/web/src/components/ThreadList.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
+import { truncatePrompt } from "../utils/sessionUtils";
 import { buildSlackThreadUrl } from "../utils/slackUtils";
 
 interface Thread {
@@ -10,6 +11,7 @@ interface Thread {
   workspace_subdomain?: string;
   session_count: number;
   latest_session_status: string;
+  initial_prompt?: string;
 }
 
 interface ThreadsResponse {
@@ -107,7 +109,7 @@ function ThreadList() {
     <div>
       <h2 className="text-xl font-semibold text-gray-900 mb-4">Threads</h2>
       {threads.length > 0 && <PaginationControls />}
-      <div className="space-y-4">
+      <div className="space-y-2">
         {threads.length === 0 ? (
           <div className="bg-white shadow rounded-lg p-6">
             <p className="text-gray-500">No threads found</p>
@@ -116,25 +118,26 @@ function ThreadList() {
           threads.map((thread) => (
             <div
               key={thread.thread_ts}
-              className="bg-white shadow rounded-lg p-6"
+              className="bg-white shadow rounded-lg p-4"
             >
-              <div className="flex justify-between items-start">
-                <div>
-                  <p className="text-sm font-medium text-gray-900">
-                    Thread: {thread.thread_time || thread.thread_ts}
-                  </p>
-                  <p className="text-sm text-gray-500">
-                    Channel: {thread.channel_name || thread.channel_id}
-                  </p>
-                  <p className="text-sm text-gray-500">
-                    Sessions: {thread.session_count} | Latest:{" "}
-                    {thread.latest_session_status}
-                  </p>
+              <div className="flex justify-between items-start mb-2">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-baseline gap-2 flex-wrap">
+                    <span className="text-sm font-semibold text-gray-900">
+                      {thread.thread_time || thread.thread_ts}
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      #{thread.channel_name || thread.channel_id} •{" "}
+                      {thread.session_count} session
+                      {thread.session_count !== 1 ? "s" : ""} •{" "}
+                      {thread.latest_session_status}
+                    </span>
+                  </div>
                 </div>
-                <div className="flex gap-2">
+                <div className="flex gap-2 ml-4 flex-shrink-0">
                   <Link
                     to={`/threads/${thread.thread_ts}/sessions`}
-                    className="inline-flex items-center px-3 py-1.5 border border-blue-300 shadow-sm text-sm font-medium rounded-md text-blue-700 bg-white hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                    className="inline-flex items-center px-2.5 py-1 border border-blue-300 shadow-sm text-xs font-medium rounded-md text-blue-700 bg-white hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
                   >
                     View Sessions
                   </Link>
@@ -142,11 +145,11 @@ function ThreadList() {
                     href={buildSlackThreadUrl(thread) || "#"}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center px-3 py-1.5 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                    className="inline-flex items-center px-2.5 py-1 border border-gray-300 shadow-sm text-xs font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
                   >
                     Open in Slack
                     <svg
-                      className="ml-2 -mr-0.5 h-4 w-4"
+                      className="ml-1.5 -mr-0.5 h-3 w-3"
                       xmlns="http://www.w3.org/2000/svg"
                       viewBox="0 0 20 20"
                       fill="currentColor"
@@ -162,6 +165,11 @@ function ThreadList() {
                   </a>
                 </div>
               </div>
+              {thread.initial_prompt && (
+                <div className="text-xs text-gray-600 leading-relaxed">
+                  {truncatePrompt(thread.initial_prompt, 200)}
+                </div>
+              )}
             </div>
           ))
         )}


### PR DESCRIPTION
## Summary
- Display initial prompt in threads list for better context (#56)
- Improve UI layout with compact design for better space utilization
- Fetch first session prompt using SQL window function

## Test plan
- [ ] Verify threads list shows initial prompts correctly
- [ ] Check that threads without initial prompts display properly
- [ ] Test pagination functionality still works
- [ ] Confirm responsive design on mobile/tablet
- [ ] Verify truncation works for long prompts (200 chars)

🤖 Generated with [Claude Code](https://claude.ai/code)