### PR TITLE
feat: improve session list UI readability

### DIFF
--- a/internal/db/queries/sessions.sql
+++ b/internal/db/queries/sessions.sql
@@ -82,7 +82,7 @@ ORDER BY started_at DESC;
 -- name: ListSessionsByThreadID :many
 SELECT * FROM sessions
 WHERE thread_id = ?
-ORDER BY started_at DESC;
+ORDER BY started_at ASC;
 
 -- name: ListSessionsPaginated :many
 SELECT * FROM sessions
@@ -92,5 +92,5 @@ LIMIT ? OFFSET ?;
 -- name: ListSessionsByThreadIDPaginated :many
 SELECT * FROM sessions
 WHERE thread_id = ?
-ORDER BY started_at DESC
+ORDER BY started_at ASC
 LIMIT ? OFFSET ?;

--- a/internal/db/sessions.sql.go
+++ b/internal/db/sessions.sql.go
@@ -240,7 +240,7 @@ func (q *Queries) ListSessions(ctx context.Context) ([]Session, error) {
 const listSessionsByThreadID = `-- name: ListSessionsByThreadID :many
 SELECT id, thread_id, session_id, started_at, ended_at, status, model, total_cost_usd, input_tokens, output_tokens, duration_ms, num_turns, initial_prompt FROM sessions
 WHERE thread_id = ?
-ORDER BY started_at DESC
+ORDER BY started_at ASC
 `
 
 func (q *Queries) ListSessionsByThreadID(ctx context.Context, threadID int64) ([]Session, error) {
@@ -283,7 +283,7 @@ func (q *Queries) ListSessionsByThreadID(ctx context.Context, threadID int64) ([
 const listSessionsByThreadIDPaginated = `-- name: ListSessionsByThreadIDPaginated :many
 SELECT id, thread_id, session_id, started_at, ended_at, status, model, total_cost_usd, input_tokens, output_tokens, duration_ms, num_turns, initial_prompt FROM sessions
 WHERE thread_id = ?
-ORDER BY started_at DESC
+ORDER BY started_at ASC
 LIMIT ? OFFSET ?
 `
 

--- a/web/src/pages/ThreadSessionsPage.tsx
+++ b/web/src/pages/ThreadSessionsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { formatDateTime } from "../utils/dateFormatter";
-import { getSessionStatusColor, truncatePrompt } from "../utils/sessionUtils";
+import { getSessionStatusColor, truncatePrompt, truncateSessionId } from "../utils/sessionUtils";
 import { buildSlackThreadUrl } from "../utils/slackUtils";
 
 interface Thread {
@@ -125,7 +125,7 @@ function ThreadSessionsPage() {
               {sessions.map((session) => (
                 <tr key={session.session_id} className="hover:bg-gray-50">
                   <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                    {session.session_id}
+                    {truncateSessionId(session.session_id)}
                   </td>
                   <td className="px-6 py-4 text-sm text-gray-500">
                     {session.initial_prompt ? (

--- a/web/src/pages/ThreadSessionsPage.tsx
+++ b/web/src/pages/ThreadSessionsPage.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { formatDateTime } from "../utils/dateFormatter";
-import { getSessionStatusColor, truncatePrompt, truncateSessionId } from "../utils/sessionUtils";
+import {
+  getSessionStatusColor,
+  truncatePrompt,
+  truncateSessionId,
+} from "../utils/sessionUtils";
 import { buildSlackThreadUrl } from "../utils/slackUtils";
 
 interface Thread {

--- a/web/src/utils/sessionUtils.test.js
+++ b/web/src/utils/sessionUtils.test.js
@@ -73,7 +73,7 @@ describe("sessionUtils", () => {
   describe("truncateSessionId", () => {
     it("should truncate long session ID", () => {
       const longId = "12345678901234567890";
-      expect(truncateSessionId(longId)).toBe("12345678...");
+      expect(truncateSessionId(longId)).toBe("12345678");
     });
 
     it("should not truncate short session ID", () => {
@@ -83,7 +83,7 @@ describe("sessionUtils", () => {
 
     it("should handle custom length", () => {
       const id = "1234567890";
-      expect(truncateSessionId(id, 4)).toBe("1234...");
+      expect(truncateSessionId(id, 4)).toBe("1234");
     });
 
     it("should return empty string for null", () => {
@@ -111,7 +111,7 @@ describe("sessionUtils", () => {
         status: "active",
       };
       const summary = getSessionSummary(session);
-      expect(summary.displayId).toBe("12345678...");
+      expect(summary.displayId).toBe("12345678");
       expect(summary.status).toBe("active");
       expect(summary.statusColor).toBe("text-green-600 bg-green-100");
     });
@@ -121,7 +121,7 @@ describe("sessionUtils", () => {
         session_id: "1234567890abcdef",
       };
       const summary = getSessionSummary(session);
-      expect(summary.displayId).toBe("12345678...");
+      expect(summary.displayId).toBe("12345678");
       expect(summary.status).toBe("unknown");
       expect(summary.statusColor).toBe("text-gray-600 bg-gray-100");
     });

--- a/web/src/utils/sessionUtils.ts
+++ b/web/src/utils/sessionUtils.ts
@@ -58,7 +58,7 @@ export const truncateSessionId = (
     return sessionId;
   }
 
-  return `${sessionId.substring(0, length)}...`;
+  return sessionId.substring(0, length);
 };
 
 export const truncatePrompt = (


### PR DESCRIPTION
## Summary
- Remove ellipsis (...) from truncated session IDs in web console
- Change **thread sessions list** sort order from newest-first to oldest-first (ascending by started_at)
- Keep all sessions list sort order as newest-first (descending)

## Why
This change improves the readability of the thread sessions list by:
1. Making session IDs easier to distinguish without the visual clutter of ellipsis
2. Presenting sessions in chronological order for better understanding of session flow within a thread

## Changes Made
- Updated `truncateSessionId` function to remove ellipsis suffix
- Updated SQL queries `ListSessionsByThreadID` and `ListSessionsByThreadIDPaginated` to use ascending order
- Updated unit tests to reflect the removal of ellipsis
- All Sessions list remains in descending order (newest first) as before

Closes #65