### PR TITLE
Remove resume window time restriction for permanent thread continuity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,7 +305,7 @@ When adding new features, always consider:
 - Bot mentions are stripped before sending to Claude
 - Responses are posted back to the same thread
 - Use structured blocks for approval prompts
-- **Session Resume**: Sessions can be resumed within a configurable time window (default: 1 hour)
+- **Session Resume**: Sessions are automatically resumed for any existing thread, maintaining permanent continuity
 
 ### MCP (Model Context Protocol) Design
 
@@ -401,22 +401,23 @@ The session resume feature allows users to continue previous Claude Code session
 ### How it works:
 
 1. When a new mention is made in a thread that had a previous session
-2. The system checks if the previous session ended within the resume window (default: 1 hour)
-3. If eligible, Claude Code is started with `--resume` option using the previous session ID
+2. The system automatically resumes the previous session if it exists
+3. Claude Code is started with `--resume` option using the previous session ID
 4. The conversation context is preserved and continues from where it left off
 
 ### Configuration:
 
-- **Resume Window**: Set via `CC_SLACK_SESSION_RESUME_WINDOW` (default: 1h)
+- **Resume Window**: The `CC_SLACK_SESSION_RESUME_WINDOW` configuration is retained for backward compatibility but no longer affects resume behavior
 - **Database**: Sessions are persisted in SQLite database
-- **Automatic**: No user action required - resume happens automatically when conditions are met
+- **Automatic**: No user action required - resume happens automatically for any existing session
 
 ### Benefits:
 
-- Seamless continuation of work across breaks
-- Preserves conversation context and memory
+- **Permanent thread continuity**: 1 Slack thread = 1 cc-slack session, regardless of time passed
+- Seamless continuation of work across any time period
+- Preserves conversation context and memory indefinitely
 - Reduces token usage by avoiding repetitive context
-- Maintains TODO lists and project state
+- Maintains TODO lists and project state permanently
 
 ## MCP Tools
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,7 +387,6 @@ Logs are written to `logs/` directory with timestamp:
 **Session Configuration:**
 - `CC_SLACK_SESSION_TIMEOUT`: Session timeout duration (default: 30m)
 - `CC_SLACK_SESSION_CLEANUP_INTERVAL`: Cleanup interval (default: 5m)
-- `CC_SLACK_SESSION_RESUME_WINDOW`: Resume window duration (default: 1h)
 
 **Working Directory Configuration:**
 - `CC_SLACK_WORKING_DIRECTORIES_DEFAULT`: Default working directory
@@ -407,7 +406,6 @@ The session resume feature allows users to continue previous Claude Code session
 
 ### Configuration:
 
-- **Resume Window**: The `CC_SLACK_SESSION_RESUME_WINDOW` configuration is retained for backward compatibility but no longer affects resume behavior
 - **Database**: Sessions are persisted in SQLite database
 - **Automatic**: No user action required - resume happens automatically for any existing session
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Once a session is started (via either mode):
    add error handling please
    ```
 3. Claude has access to the selected working directory (as permitted by Claude Code configuration)
-4. Sessions automatically resume if you return within the resume window (default: 1 hour)
+4. Sessions automatically resume when you return to the same thread
 
 ### Message Filtering
 

--- a/cmd/cc-slack/main.go
+++ b/cmd/cc-slack/main.go
@@ -234,7 +234,6 @@ func main() {
 	log.Printf("Slack webhook endpoint: %s/slack/events", cfg.Server.BaseURL)
 	log.Printf("Session timeout: %v", cfg.Session.Timeout)
 	log.Printf("Cleanup interval: %v", cfg.Session.CleanupInterval)
-	log.Printf("Resume window: %v", cfg.Session.ResumeWindow)
 	log.Printf("Database path: %s", cfg.Database.Path)
 
 	// Log working directory mode

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -69,8 +69,6 @@ session:
   timeout: 30m
   # Interval for cleaning up expired sessions
   cleanup_interval: 5m
-  # Window for resuming previous sessions (must be longer than timeout)
-  resume_window: 1h
 
 # Logging configuration
 logging:

--- a/docs/design.md
+++ b/docs/design.md
@@ -1105,7 +1105,6 @@ database:
 session:
   timeout: "30m"
   cleanup_interval: "5m"
-  resume_window: "1h"  # セッション再開可能な時間
 
 working_directories:
   default: "/home/user/workspace"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,7 +66,6 @@ type DatabaseConfig struct {
 type SessionConfig struct {
 	Timeout         time.Duration `mapstructure:"timeout"`
 	CleanupInterval time.Duration `mapstructure:"cleanup_interval"`
-	ResumeWindow    time.Duration `mapstructure:"resume_window"`
 }
 
 // LoggingConfig contains logging settings
@@ -127,7 +126,6 @@ func Load() (*Config, error) {
 	v.BindEnv("database.migrations_path")
 	v.BindEnv("session.timeout")
 	v.BindEnv("session.cleanup_interval")
-	v.BindEnv("session.resume_window")
 
 	// Set defaults with the new viper instance
 	setDefaultsWithViper(v)
@@ -171,7 +169,6 @@ func setDefaultsWithViper(v *viper.Viper) {
 	// Session defaults
 	v.SetDefault("session.timeout", "30m")
 	v.SetDefault("session.cleanup_interval", "5m")
-	v.SetDefault("session.resume_window", "1h")
 
 	// Logging defaults
 	v.SetDefault("logging.level", "info")
@@ -216,9 +213,6 @@ func (c *Config) validate() error {
 	}
 	if c.Session.CleanupInterval <= 0 {
 		return fmt.Errorf("session.cleanup_interval must be positive")
-	}
-	if c.Session.ResumeWindow <= 0 {
-		return fmt.Errorf("session.resume_window must be positive")
 	}
 
 	// If working directories are specified via command-line, no validation needed for WorkingDirs

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,10 +41,6 @@ func TestConfigDefaults(t *testing.T) {
 		t.Errorf("expected default timeout 30m, got %v", cfg.Session.Timeout)
 	}
 
-	if cfg.Session.ResumeWindow != time.Hour {
-		t.Errorf("expected default resume window 1h, got %v", cfg.Session.ResumeWindow)
-	}
-
 	if cfg.Slack.SlashCommandName != "/cc" {
 		t.Errorf("expected default slash command name /cc, got %s", cfg.Slack.SlashCommandName)
 	}
@@ -61,7 +57,6 @@ func TestConfigEnvironment(t *testing.T) {
 	os.Setenv("CC_SLACK_SLACK_SIGNING_SECRET", "test-secret")
 	os.Setenv("CC_SLACK_SERVER_PORT", "9090")
 	os.Setenv("CC_SLACK_DATABASE_PATH", "/custom/path/db.sqlite")
-	os.Setenv("CC_SLACK_SESSION_RESUME_WINDOW", "2h")
 	os.Setenv("CC_SLACK_SLACK_SLASH_COMMAND_NAME", "/cc")
 
 	defer func() {
@@ -69,7 +64,6 @@ func TestConfigEnvironment(t *testing.T) {
 		os.Unsetenv("CC_SLACK_SLACK_SIGNING_SECRET")
 		os.Unsetenv("CC_SLACK_SERVER_PORT")
 		os.Unsetenv("CC_SLACK_DATABASE_PATH")
-		os.Unsetenv("CC_SLACK_SESSION_RESUME_WINDOW")
 		os.Unsetenv("CC_SLACK_SLACK_SLASH_COMMAND_NAME")
 	}()
 
@@ -86,10 +80,6 @@ func TestConfigEnvironment(t *testing.T) {
 
 	if cfg.Database.Path != "/custom/path/db.sqlite" {
 		t.Errorf("expected database path from env, got %s", cfg.Database.Path)
-	}
-
-	if cfg.Session.ResumeWindow != 2*time.Hour {
-		t.Errorf("expected resume window 2h from env, got %v", cfg.Session.ResumeWindow)
 	}
 
 	if cfg.Slack.SlashCommandName != "/cc" {

--- a/internal/process/resume.go
+++ b/internal/process/resume.go
@@ -4,22 +4,19 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"time"
 
 	"github.com/yuya-takeyama/cc-slack/internal/db"
 )
 
 // ResumeManager manages session resume functionality
 type ResumeManager struct {
-	queries      *db.Queries
-	resumeWindow time.Duration
+	queries *db.Queries
 }
 
 // NewResumeManager creates a new ResumeManager
-func NewResumeManager(queries *db.Queries, resumeWindow time.Duration) *ResumeManager {
+func NewResumeManager(queries *db.Queries) *ResumeManager {
 	return &ResumeManager{
-		queries:      queries,
-		resumeWindow: resumeWindow,
+		queries: queries,
 	}
 }
 

--- a/internal/process/resume.go
+++ b/internal/process/resume.go
@@ -62,17 +62,13 @@ func (rm *ResumeManager) ShouldResume(ctx context.Context, channelID, threadTS s
 		return false, "", fmt.Errorf("failed to get session details: %w", err)
 	}
 
-	// Check if session ended within resume window
+	// Check if session has ended (active sessions should not be resumed)
 	if !session.EndedAt.Valid {
 		return false, "", nil
 	}
 
-	timeSinceEnd := time.Since(session.EndedAt.Time)
-	if timeSinceEnd <= rm.resumeWindow {
-		return true, sessionID, nil
-	}
-
-	return false, "", nil
+	// Always resume if a previous session exists, regardless of time
+	return true, sessionID, nil
 }
 
 // CheckActiveSession checks if there's already an active session for the thread

--- a/internal/process/resume_test.go
+++ b/internal/process/resume_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"testing"
-	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/yuya-takeyama/cc-slack/internal/database"
@@ -37,7 +36,7 @@ func TestResumeManager_GetLatestSessionID(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
-	rm := NewResumeManager(queries, time.Hour)
+	rm := NewResumeManager(queries)
 
 	// Create test thread
 	thread, err := queries.CreateThread(ctx, db.CreateThreadParams{
@@ -84,7 +83,7 @@ func TestResumeManager_GetLatestSessionID_NoThread(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
-	rm := NewResumeManager(queries, time.Hour)
+	rm := NewResumeManager(queries)
 
 	// Test with non-existent thread
 	_, err := rm.GetLatestSessionID(ctx, "C999999", "9999999999.999999")
@@ -98,7 +97,7 @@ func TestResumeManager_ShouldResume(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
-	rm := NewResumeManager(queries, 30*time.Minute)
+	rm := NewResumeManager(queries)
 
 	// Create test thread
 	thread, err := queries.CreateThread(ctx, db.CreateThreadParams{
@@ -149,7 +148,7 @@ func TestResumeManager_ShouldResume_OutsideWindow(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
-	rm := NewResumeManager(queries, 30*time.Minute)
+	rm := NewResumeManager(queries)
 
 	// Create test thread
 	thread, err := queries.CreateThread(ctx, db.CreateThreadParams{
@@ -200,7 +199,7 @@ func TestResumeManager_CheckActiveSession(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
-	rm := NewResumeManager(queries, time.Hour)
+	rm := NewResumeManager(queries)
 
 	// Create test thread
 	thread, err := queries.CreateThread(ctx, db.CreateThreadParams{

--- a/internal/process/resume_test.go
+++ b/internal/process/resume_test.go
@@ -128,7 +128,7 @@ func TestResumeManager_ShouldResume(t *testing.T) {
 		t.Fatalf("failed to update session: %v", err)
 	}
 
-	// Should resume (within window)
+	// Should resume
 	shouldResume, sessionID, err := rm.ShouldResume(ctx, "C123456", "1234567890.123456")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -143,7 +143,7 @@ func TestResumeManager_ShouldResume(t *testing.T) {
 	}
 }
 
-func TestResumeManager_ShouldResume_OutsideWindow(t *testing.T) {
+func TestResumeManager_ShouldResume_LongElapsedTime(t *testing.T) {
 	sqlDB, queries, cleanup := setupTestDB(t)
 	defer cleanup()
 
@@ -179,14 +179,14 @@ func TestResumeManager_ShouldResume_OutsideWindow(t *testing.T) {
 		t.Fatalf("failed to update session: %v", err)
 	}
 
-	// Should always resume now, regardless of time window
+	// Should always resume regardless of elapsed time
 	shouldResume, sessionID, err := rm.ShouldResume(ctx, "C123456", "1234567890.123456")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if !shouldResume {
-		t.Error("expected shouldResume to be true even outside window")
+		t.Error("expected shouldResume to be true regardless of elapsed time")
 	}
 
 	if sessionID != "test-session-old" {

--- a/internal/process/resume_test.go
+++ b/internal/process/resume_test.go
@@ -180,14 +180,18 @@ func TestResumeManager_ShouldResume_OutsideWindow(t *testing.T) {
 		t.Fatalf("failed to update session: %v", err)
 	}
 
-	// Should not resume (outside window)
-	shouldResume, _, err := rm.ShouldResume(ctx, "C123456", "1234567890.123456")
+	// Should always resume now, regardless of time window
+	shouldResume, sessionID, err := rm.ShouldResume(ctx, "C123456", "1234567890.123456")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if shouldResume {
-		t.Error("expected shouldResume to be false")
+	if !shouldResume {
+		t.Error("expected shouldResume to be true even outside window")
+	}
+
+	if sessionID != "test-session-old" {
+		t.Errorf("expected session ID %s, got %s", "test-session-old", sessionID)
 	}
 }
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -749,19 +749,13 @@ func (m *Manager) ShouldResume(ctx context.Context, channelID, threadTS string) 
 		return false, "", fmt.Errorf("failed to get latest session: %w", err)
 	}
 
-	// Check if session ended within resume window
+	// Check if session has ended (active sessions should not be resumed)
 	if !session.EndedAt.Valid {
 		return false, "", nil
 	}
 
-	resumeWindow := m.config.Session.ResumeWindow
-	timeSinceEnd := time.Since(session.EndedAt.Time)
-
-	if timeSinceEnd <= resumeWindow {
-		return true, session.SessionID, nil
-	}
-
-	return false, "", nil
+	// Always resume if a previous session exists, regardless of time
+	return true, session.SessionID, nil
 }
 
 func (m *Manager) CheckActiveSession(ctx context.Context, channelID, threadTS string) (bool, error) {


### PR DESCRIPTION
## Summary
- Removed time-based restrictions from session resume functionality
- Sessions now resume automatically regardless of elapsed time
- Implements the principle: 1 Slack thread = 1 cc-slack session permanently
- **Completely removed CC_SLACK_SESSION_RESUME_WINDOW configuration** (no backward compatibility)

## Test plan
- [x] Updated unit tests to verify sessions resume after any time period
- [x] All tests pass with `./scripts/check-all`
- [ ] Manual testing: Create a session, wait beyond previous 1-hour window, verify it still resumes
- [x] Removed all references to resume window configuration

Closes #68

🤖 Generated with [Claude Code](https://claude.ai/code)