### PR TITLE
feat: display channel name instead of ID in thread detail view

### DIFF
--- a/web/src/pages/ThreadSessionsPage.tsx
+++ b/web/src/pages/ThreadSessionsPage.tsx
@@ -11,6 +11,7 @@ import { buildSlackThreadUrl } from "../utils/slackUtils";
 interface Thread {
   thread_ts: string;
   channel_id: string;
+  channel_name?: string;
   workspace_subdomain?: string;
 }
 
@@ -84,7 +85,9 @@ function ThreadSessionsPage() {
             </div>
             <div>
               <p className="text-sm text-gray-600">Channel</p>
-              <p className="font-medium">{thread.channel_id}</p>
+              <p className="font-medium">
+                {thread.channel_name || thread.channel_id}
+              </p>
             </div>
           </div>
           <a


### PR DESCRIPTION
## Summary
- Replace channel ID display with human-readable channel names in the thread detail view
- Add support for different channel types (public, private, DM, group DM) with appropriate prefixes
- Maintain fallback to channel ID when name is unavailable

## Implementation Details
- Enhanced `ChannelInfo` struct to include channel type flags
- Updated `GetChannelName` to format names based on channel type:
  - Public channels: `#channel-name`
  - Private channels: `🔒channel-name`
  - Direct messages: "Direct Message"
  - Group DMs: "Group DM"
- Frontend now displays `channel_name` from API response with fallback to `channel_id`
- Leverages existing channel caching mechanism for performance

## Test Plan
- [ ] Test with public channels - should show `#channel-name`
- [ ] Test with private channels - should show `🔒channel-name`
- [ ] Test with direct messages - should show "Direct Message"
- [ ] Test with group DMs - should show "Group DM"
- [ ] Test with channels where API fails - should fallback to channel ID
- [ ] Verify channel names are properly cached to avoid excessive API calls

Closes #57

🤖 Generated with [Claude Code](https://claude.ai/code)