### PR TITLE
fix: show full content in approval prompts without truncation

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -246,9 +246,7 @@ func (s *Server) HandleApprovalPrompt(ctx context.Context, session *mcpsdk.Serve
 				if url, ok := params.Arguments.Input["url"].(string); ok {
 					message += fmt.Sprintf("\n\n**URL**: %s", url)
 				}
-				if prompt, ok := params.Arguments.Input["prompt"].(string); ok && len(prompt) > 100 {
-					message += fmt.Sprintf("\n**Content**: %s...", prompt[:100])
-				} else if prompt, ok := params.Arguments.Input["prompt"].(string); ok && prompt != "" {
+				if prompt, ok := params.Arguments.Input["prompt"].(string); ok && prompt != "" {
 					message += fmt.Sprintf("\n**Content**: %s", prompt)
 				}
 


### PR DESCRIPTION
## Summary
- Remove 100-character truncation limit for prompt content in Slack approval messages
- Users can now see the complete content when approving MCP tool executions
- Improves transparency and security by showing exactly what will be executed

## Background
Previously, when Claude Code requested permission to execute tools (like mcp__any-script__codex-search), the content was truncated at 100 characters with "..." in the Slack approval prompt. This made it difficult for users to make informed decisions about whether to approve the execution.

## Changes
- Modified `internal/mcp/server.go` to remove the content truncation logic
- All prompt content is now displayed in full in the approval message

## Test plan
- [x] Build cc-slack successfully
- [ ] Test with a long MCP tool prompt (> 100 characters)
- [ ] Verify that the full content appears in the Slack approval message
- [ ] Confirm that approval/denial still works correctly

---
Generated with Claude assistance