### PR TITLE
fix: handle multi-line content in approval prompts

### DIFF
--- a/internal/slack/blocks/blocks.go
+++ b/internal/slack/blocks/blocks.go
@@ -196,18 +196,62 @@ type ApprovalInfo struct {
 func parseApprovalMessage(message string) *ApprovalInfo {
 	info := &ApprovalInfo{}
 	lines := strings.Split(message, "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
+
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+
 		if strings.HasPrefix(line, "**Tool**: ") {
 			info.ToolName = strings.TrimPrefix(line, "**Tool**: ")
 		} else if strings.HasPrefix(line, "**URL**: ") {
 			info.URL = strings.TrimPrefix(line, "**URL**: ")
 		} else if strings.HasPrefix(line, "**Content**: ") {
-			info.Prompt = strings.TrimPrefix(line, "**Content**: ")
+			// Collect all content until the next field or end
+			content := strings.TrimPrefix(line, "**Content**: ")
+			for j := i + 1; j < len(lines); j++ {
+				nextLine := strings.TrimSpace(lines[j])
+				// Stop if we hit another field marker
+				if strings.HasPrefix(nextLine, "**") && strings.Contains(nextLine, ": ") {
+					break
+				}
+				// Add newline and the line content
+				if content != "" {
+					content += "\n"
+				}
+				content += lines[j] // Keep original formatting
+			}
+			info.Prompt = content
 		} else if strings.HasPrefix(line, "**Command**: ") {
-			info.Command = strings.TrimPrefix(line, "**Command**: ")
+			// Collect all command content until the next field or end
+			command := strings.TrimPrefix(line, "**Command**: ")
+			for j := i + 1; j < len(lines); j++ {
+				nextLine := strings.TrimSpace(lines[j])
+				// Stop if we hit another field marker
+				if strings.HasPrefix(nextLine, "**") && strings.Contains(nextLine, ": ") {
+					break
+				}
+				// Add newline and the line content
+				if command != "" {
+					command += "\n"
+				}
+				command += lines[j] // Keep original formatting
+			}
+			info.Command = command
 		} else if strings.HasPrefix(line, "**Description**: ") {
-			info.Description = strings.TrimPrefix(line, "**Description**: ")
+			// Collect all description content until the next field or end
+			description := strings.TrimPrefix(line, "**Description**: ")
+			for j := i + 1; j < len(lines); j++ {
+				nextLine := strings.TrimSpace(lines[j])
+				// Stop if we hit another field marker
+				if strings.HasPrefix(nextLine, "**") && strings.Contains(nextLine, ": ") {
+					break
+				}
+				// Add newline and the line content
+				if description != "" {
+					description += "\n"
+				}
+				description += lines[j] // Keep original formatting
+			}
+			info.Description = description
 		} else if strings.HasPrefix(line, "**File path**: ") {
 			info.FilePath = strings.TrimPrefix(line, "**File path**: ")
 		}


### PR DESCRIPTION
## Summary
- Fix multi-line content parsing in Slack approval messages
- Preserve all lines of prompts, commands, and descriptions
- Properly handle content that spans multiple lines

## Problem
After the previous fix (#75) that removed the 100-character truncation, multi-line content still only showed the first line. This was because the `parseApprovalMessage` function in `blocks.go` was splitting by newlines and only taking the first line after each field marker.

## Solution
Modified the parsing logic to:
1. Collect all lines after a field marker until the next field marker
2. Preserve original formatting and newlines
3. Apply this to **Content**, **Command**, and **Description** fields

## Test plan
- [x] Build cc-slack successfully
- [ ] Test with multi-line MCP tool prompts
- [ ] Verify that all lines appear in the Slack approval message
- [ ] Confirm that approval/denial still works correctly
- [ ] Test with various tools (codex-search, bash with multi-line scripts, etc.)

## Example
Before: Only "哲学の歴史について以下の観点から詳しく調べてください：" was shown
After: Full multi-line prompt with all bullet points is displayed

---
Generated with Claude assistance